### PR TITLE
publish vsix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,14 @@ after_success:
   - if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" ]]; then
     sonar-scanner;
     fi
+deploy:
+- provider: script
+  script: vsce publish -p $VSCODE_TOKEN
+  skip_cleanup: true
+  on:
+    repo: jboss-fuse/vscode-atlasmap
+    branch: master
+    tags: true
 cache:
   directories:
     - "node_modules"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,3 +7,4 @@ gulpfile.js
 sonar-project.properties
 tsconfig.json
 tslint.json
+Contributing.md

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,17 @@
+# How to provide a new version on VS Code Marketplace
+
+* Check that the version in package.json has not been published yet
+  * If already published:
+    * Upgrade the version in package.json
+    * Run 'npm install' so that the package-lock.json is updated
+    * Push changes in a PR
+    * Wait for PR to be merged
+* Create a tag
+* Push the tag to camel-tooling repository, it will trigger a build after few minutes
+* Check build is working fine on [Travis CI](https://travis-ci.org/jboss-fuse/vscode-atlasmap)
+* Wait that the new plugin version is validated by VS Code marketplace moderators (can take minutes or days)
+* Prepare next iteration:
+  * Upgrade the version in package.json
+  * Run 'npm install' so that the package-lock.json is updated
+  * Push changes in a PR
+  * Follow PR until it is approved/merged


### PR DESCRIPTION
https://github.com/jboss-fuse/vscode-atlasmap/pull/22 to be merged first

I've done it manually and it was successfully deployed:
```
C:\git\vscode-atlasmap>vsce publish -p <theVSCodeTokenThatIConfiguredOnTravisCI>
Executing prepublish script 'npm run vscode:prepublish'...

> atlasmap-viewer@0.0.1 vscode:prepublish C:\git\vscode-atlasmap
> tsc -p ./

Publishing jboss-fuse.atlasmap-viewer@0.0.1...
Successfully published jboss-fuse.atlasmap-viewer@0.0.1!
Your extension will live at https://marketplace.visualstudio.com/items?itemName=jboss-fuse.atlasmap-viewer (might take a few seconds for it to show up).
```

![image](https://user-images.githubusercontent.com/1105127/51174970-5eccb080-18b9-11e9-8852-632b16225a88.png)

I've deleted the extension after to ensure that the first publish will work :-)