### PR TITLE
removed the obsolete atlasmap command from activation events #56

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
 		]
 	},
 	"activationEvents": [
-		"onCommand:atlasmap.open",
 		"onCommand:atlasmap.start"
 	],
 	"scripts": {


### PR DESCRIPTION
Signed-off-by: Lars Heinemann <lhein.smx@gmail.com>