### PR TITLE
handover ADM file path to AtlasMap startup #7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,7 +1629,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1650,12 +1651,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1670,17 +1673,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1797,7 +1803,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1809,6 +1816,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1823,6 +1831,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1830,12 +1839,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -1854,6 +1865,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1934,7 +1946,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1946,6 +1959,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2031,7 +2045,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2067,6 +2082,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2086,6 +2102,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2129,12 +2146,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1439,6 +1439,18 @@
 				"encoding": "0.1.12"
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true
+		},
+		"file-url": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/file-url/-/file-url-2.0.2.tgz",
+			"integrity": "sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4=",
+			"dev": true
+		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"version": "0.0.1",
 	"publisher": "jboss-fuse",
 	"preview": true,
+	"config": {
+		"atlasmapversion": "1.39.4"
+	},	
 	"bugs": "https://github.com/jboss-fuse/vscode-atlasmap/issues",
 	"homepage": "https://github.com/jboss-fuse/vscode-atlasmap",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,15 @@
 				"category": "AtlasMap"
 			}
 		],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "atlasmap.start",
+					"when": "resourceExtname == .adm",
+					"group": "navigation"
+				}
+			]
+		},
 		"configuration": {
 			"type": "object",
 			"title": "AtlasMap Settings",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,8 @@
 		"@types/sinon-chai": "^3.2.1",
 		"assert": "^1.4.1",
 		"chai": "^4.2.0",
+		"file-uri-to-path": "^1.0.0",
+		"file-url": "^2.0.2",
 		"fs": "^0.0.1-security",
 		"gulp": "^4.0.0",
 		"gulp-tslint": "^8.1.3",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var atlasmap_server_version = "1.39.3";
+var atlasmap_server_version = "1.39.4";
 
 const download = require("mvn-artifact-download").default;
 const fs = require('fs');

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var atlasmap_server_version = "1.39.4";
-
 const download = require("mvn-artifact-download").default;
 const fs = require('fs');
 const path = require('path');
+
+const atlasmap_server_version = process.env.npm_package_config_atlasmapversion;
 
 download('io.atlasmap:atlasmap-standalone:' + atlasmap_server_version, './jars/').then((filename)=>{
 	fs.renameSync(filename, path.join('.', 'jars', 'atlasmap-standalone.jar'));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,7 +103,7 @@ function launchAtlasMapLocally(atlasmapExecutablePath: string, port: string, adm
 			.then(requirements => {
 				let javaExecutablePath = path.resolve(requirements.java_home + '/bin/java');
 
-				if (admFilePath !== "") {
+				if (admFilePath !== "") {										
 					atlasMapProcess = child_process.spawn(javaExecutablePath, ['-Datlasmap.adm.path=' + admFilePath, '-jar', atlasmapExecutablePath]);
 				} else {
 					atlasMapProcess = child_process.spawn(javaExecutablePath, ['-jar', atlasmapExecutablePath]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
 		// another AtlasMap instance if there is already one running.
 		if (isAtlasMapRunning() && admFilePath === undefined && (ctx === undefined || ctx.fsPath === undefined)) {
 			// no need to start another atlasmap instance - just open it again
+			vscode.window.showInformationMessage("Running AtlasMap instance found at port " + atlasMapLaunchPort);
 			openURL(generateUrl(atlasMapLaunchPort));
 			return;
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,8 +22,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('atlasmap.start', (ctx) => {
 		let admFilePath: string;
-		if (ctx && ctx.path) {
-			admFilePath = ctx.path;
+		if (ctx && ctx.fsPath) {
+			admFilePath = ctx.fsPath;
 		}
 
 		ensureNoOtherAtlasMapInstanceRunning()
@@ -103,7 +103,7 @@ function launchAtlasMapLocally(atlasmapExecutablePath: string, port: string, adm
 			.then(requirements => {
 				let javaExecutablePath = path.resolve(requirements.java_home + '/bin/java');
 
-				if (admFilePath !== "") {										
+				if (admFilePath !== "") {
 					atlasMapProcess = child_process.spawn(javaExecutablePath, ['-Datlasmap.adm.path=' + admFilePath, '-jar', atlasmapExecutablePath]);
 				} else {
 					atlasMapProcess = child_process.spawn(javaExecutablePath, ['-jar', atlasmapExecutablePath]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,8 @@ let admFilePath: string;
 
 const WAIT_STEP: number = 1000;
 const MAX_WAIT: number = 30000;
+export const WARN_MSG: string = "There is currently a local AtlasMap instance running. We need to restart that instance. Make sure you have saved all your changes in the AtlasMap UI to prevent data loss.";
+export const RESTART_CHOICE: string = "Restart";
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -82,8 +84,8 @@ function ensureNoOtherAtlasMapInstanceRunning(): Promise<boolean> {
 	return new Promise( async (resolve, reject) => {
 		if (isAtlasMapRunning()) {
 			// we need to stop a running atlasmap to make the next import work
-			let choice = await vscode.window.showWarningMessage("There is currently a local AtlasMap instance running. We need to restart that instance. Make sure you have saved all your changes in the AtlasMap UI to prevent data loss.", { modal: true }, "Restart");
-			if ("Restart" === choice) {
+			let choice = await vscode.window.showWarningMessage(WARN_MSG, { modal: true }, RESTART_CHOICE);
+			if (RESTART_CHOICE === choice) {
 				handleStopAtlasMap();
 
 				let waitTimer:number = 0;

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -75,6 +75,35 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 				});
 		});
 
+		it("Test Start Command invocation with running AtlasMap instance (DO NOT SPAWN MORE THAN ONE ATLASMAP)", function(done) {
+			expect(port).to.be.undefined;
+			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)
+				.then( async (_port) => {
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					port = _port;
+					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+					expect(createOutputChannelSpy.calledOnce);
+
+					await vscode.commands.executeCommand("atlasmap.start");
+					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(1);
+					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
+
+					await vscode.commands.executeCommand("atlasmap.start");
+					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(2);
+					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
+
+					// wait a bit for the web ui  to be ready - not nice but works fine
+					await new Promise(resolve => setTimeout(resolve, 3000));
+
+					done();
+				})
+				.catch( err => {
+					console.error(err);
+					done(err);
+				});
+		});
+
 		it("Test Web UI availability after startup of server", function(done) {
 			expect(port).to.be.undefined;
 			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -3,17 +3,16 @@
 import * as atlasMapWebView from "../atlasMapWebView";
 import * as chai from "chai";
 import * as child_process from 'child_process';
+import * as fs from "fs";
 import * as sinon from "sinon";
 import * as sinonChai from "sinon-chai";
 import * as testUtils from "./command.test.utils";
 import * as vscode from "vscode";
 import { BrowserType } from "../utils";
+import { RESTART_CHOICE, WARN_MSG } from '../extension';
 
-const fs = require("fs");
 const expect = chai.expect;
 chai.use(sinonChai);
-
-const WARN_MSG:string = "There is currently a local AtlasMap instance running. We need to restart that instance. Make sure you have saved all your changes in the AtlasMap UI to prevent data loss.";
 
 testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 	describe("Start AtlasMap Command Tests with browser type: " + browserConfig, function() {
@@ -34,7 +33,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 			showWarningMessageStub = sinon.stub(vscode.window, "showWarningMessage");
 			showWarningMessageStub.withArgs(WARN_MSG, sinon.match.any).callsFake((args) => {
 				console.log("Restart warning message shown: " + args);
-			}).returns("Restart");
+			}).returns(RESTART_CHOICE);
 			showWarningMessageStub.callThrough();
 			showInformationMessageSpy = sinon.spy(vscode.window, "showInformationMessage");
 			createOutputChannelSpy = sinon.spy(vscode.window, "createOutputChannel");

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -9,42 +9,62 @@ import * as testUtils from "./command.test.utils";
 import * as vscode from "vscode";
 import { BrowserType } from "../utils";
 
+const fs = require("fs");
 const expect = chai.expect;
 chai.use(sinonChai);
+
+const WARN_MSG:string = "There is currently a local AtlasMap instance running. We need to restart that instance. Make sure you have saved all your changes in the AtlasMap UI to prevent data loss.";
 
 testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 	describe("Start AtlasMap Command Tests with browser type: " + browserConfig, function() {
 
 		let sandbox: sinon.SinonSandbox;
 		let executeCommandStub: sinon.SinonStub;
+		let showWarningMessageStub: sinon.SinonStub;
 		let showInformationMessageSpy: sinon.SinonSpy;
 		let createOutputChannelSpy: sinon.SinonSpy;
 		let spawnChildProcessSpy: sinon.SinonSpy;
 		let port: string;
+		let testADMFileWorking: string;
+		let testADMFileBroken: string;
 
 		before(function() {
 			sandbox = sinon.createSandbox();
 			executeCommandStub = testUtils.createExecuteCommandStubFakingExternalOpenBrowserCall();
+			showWarningMessageStub = sinon.stub(vscode.window, "showWarningMessage");
+			showWarningMessageStub.withArgs(WARN_MSG, sinon.match.any).callsFake((args) => {
+				console.log("Restart warning message shown: " + args);
+			}).returns("Restart");
+			showWarningMessageStub.callThrough();
 			showInformationMessageSpy = sinon.spy(vscode.window, "showInformationMessage");
 			createOutputChannelSpy = sinon.spy(vscode.window, "createOutputChannel");
 			spawnChildProcessSpy = sinon.spy(child_process, "spawn");
 			testUtils.switchSettingsToType(browserConfig);
+			testADMFileWorking = testUtils.downloadTestADM();
+			testADMFileBroken = testUtils.createBrokenADM();
 		});
 
 		after(function() {
 			executeCommandStub.restore();
+			showWarningMessageStub.restore();
 			showInformationMessageSpy.restore();
 			createOutputChannelSpy.restore();
 			spawnChildProcessSpy.restore();
 			sandbox.restore();
-			port =  undefined;
 			testUtils.switchSettingsToType(undefined);
+			fs.unlink(testADMFileWorking, (err) => {
+				if (err) throw err;
+			});
+			fs.unlink(testADMFileBroken, (err) => {
+				if (err) throw err;
+			});
 		});
 
 		afterEach(function(done) {
 			testUtils.stopAtlasMapInstance(port, showInformationMessageSpy)
 				.then( () => {
 					executeCommandStub.resetHistory();
+					showWarningMessageStub.resetHistory();
 					showInformationMessageSpy.resetHistory();
 					createOutputChannelSpy.resetHistory();
 					spawnChildProcessSpy.resetHistory();
@@ -133,6 +153,128 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 					done(err);
 				});
 		});
+
+		it("Test import of ADM file with stopped server", function(done) {
+			expect(port).to.be.undefined;
+			let context = { fsPath: testADMFileWorking };
+			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy, context)
+				.then( async (_port) => {
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					port = _port;
+					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+					expect(createOutputChannelSpy.calledOnce);
+
+					let url:string = "http://localhost:" + port;
+					await testUtils.getWebUI(url)
+						.then( (body) => {
+							expect(body, "Unexpected html response body").to.contain("AtlasMap");
+							if (browserConfig === BrowserType.Internal) {
+								expect(atlasMapWebView.default.currentPanel._panel.webview.html, "HTML doesn't contain url or the body tag with zero padding").to.contain(url).and.to.contain('<body style="padding: 0">');
+							}
+							done();
+						})
+						.catch( (err) => {
+							console.error(err);
+							done(err);
+						});
+				})
+				.catch( err => {
+					console.error(err);
+					done(err);
+				});
+		});
+
+		it("Test import of ADM file with running server", function(done) {
+			expect(port).to.be.undefined;
+			let context = { fsPath: testADMFileWorking };
+			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy, context)
+				.then( async (_port) => {
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					port = _port;
+					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+					expect(createOutputChannelSpy.calledOnce);
+
+					let url:string = "http://localhost:" + port;
+					await testUtils.getWebUI(url)
+						.then( (body) => {
+							expect(body, "Unexpected html response body").to.contain("AtlasMap");
+							if (browserConfig === BrowserType.Internal) {
+								expect(atlasMapWebView.default.currentPanel._panel.webview.html, "HTML doesn't contain url or the body tag with zero padding").to.contain(url).and.to.contain('<body style="padding: 0">');
+							}
+
+
+							testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy, context)
+							.then( async (_port) => {
+								expect(showWarningMessageStub.withArgs(WARN_MSG).calledOnce, "There was no warning dialog shown when starting another instance with an ADM import specified.").to.be.true;
+								expect(executeCommandStub.withArgs("atlasmap.start").calledTwice, "AtlasMap start command was not issued").to.be.true;
+								port = _port;
+								expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+								expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+								expect(createOutputChannelSpy.calledTwice);
+			
+								let url:string = "http://localhost:" + port;
+								await testUtils.getWebUI(url)
+									.then( (body) => {
+										expect(body, "Unexpected html response body").to.contain("AtlasMap");
+										if (browserConfig === BrowserType.Internal) {
+											expect(atlasMapWebView.default.currentPanel._panel.webview.html, "HTML doesn't contain url or the body tag with zero padding").to.contain(url).and.to.contain('<body style="padding: 0">');
+										}
+										done();
+									})
+									.catch( (err) => {
+										console.error(err);
+										done(err);
+									});
+							})
+							.catch( err => {
+								console.error(err);
+								done(err);
+							});
+						})
+						.catch( (err) => {
+							console.error(err);
+							done(err);
+						});
+				})
+				.catch( err => {
+					console.error(err);
+					done(err);
+				});
+		});
+
+		it("Test import of corrupted ADM file with stopped server", function(done) {
+			expect(port).to.be.undefined;
+			let context = { fsPath: testADMFileBroken };
+			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy, context)
+				.then( async (_port) => {
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					port = _port;
+					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+					expect(createOutputChannelSpy.calledOnce);
+
+					let url:string = "http://localhost:" + port;
+					await testUtils.getWebUI(url)
+						.then( (body) => {
+							expect(body, "Unexpected html response body").to.contain("AtlasMap");
+							if (browserConfig === BrowserType.Internal) {
+								expect(atlasMapWebView.default.currentPanel._panel.webview.html, "HTML doesn't contain url or the body tag with zero padding").to.contain(url).and.to.contain('<body style="padding: 0">');
+							}
+							done();
+						})
+						.catch( (err) => {
+							console.error(err);
+							done(err);
+						});
+				})
+				.catch( err => {
+					console.error(err);
+					done(err);
+				});
+		});
+
 	});
 });
 

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -75,35 +75,6 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 				});
 		});
 
-		it("Test Start Command invocation with running AtlasMap instance (DO NOT SPAWN MORE THAN ONE ATLASMAP)", function(done) {
-			expect(port).to.be.undefined;
-			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)
-				.then( async (_port) => {
-					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
-					port = _port;
-					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
-					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
-					expect(createOutputChannelSpy.calledOnce);
-
-					await vscode.commands.executeCommand("atlasmap.start");
-					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(1);
-					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
-		
-					await vscode.commands.executeCommand("atlasmap.start");
-					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(2);
-					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
-		
-					// wait a bit for the web ui  to be ready - not nice but works fine
-					await new Promise(resolve => setTimeout(resolve, 3000));
-
-					done();
-				})
-				.catch( err => {
-					console.error(err);
-					done(err);
-				});
-		});
-
 		it("Test Web UI availability after startup of server", function(done) {
 			expect(port).to.be.undefined;
 			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)

--- a/src/test/command.test.utils.ts
+++ b/src/test/command.test.utils.ts
@@ -1,17 +1,17 @@
 "use strict";
 
 import * as chai from "chai";
+import * as fileUrl from "file-url";
+import * as fs from "fs";
 import { DEFAULT_ATLASMAP_PORT, BrowserType, BROWSERTYPE_PREFERENCE_KEY } from '../utils';
 import { isString } from "util";
+import * as request from "request";
 import * as sinon from "sinon";
 import * as sinonChai from "sinon-chai";
 import * as vscode from "vscode";
 import AtlasMapPanel from '../atlasMapWebView';
 
-const request = require("request");
-const fileUrl = require('file-url');
 const uri2path = require('file-uri-to-path');
-const fs = require("fs");
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -19,6 +19,8 @@ chai.use(sinonChai);
 const MAX_WAIT = 10000;
 const STEP = 1000;
 const KEYSTRING: string = "Starting AtlasMap instance at port ";
+
+export const ATLASMAP_SERVER_VERSION = process.env.npm_package_config_atlasmapversion;
 
 export const BROWSER_TYPES = [BrowserType.Internal, BrowserType.External];
 
@@ -164,11 +166,16 @@ export function createExecuteCommandStubFakingExternalOpenBrowserCall() {
 
 export function downloadTestADM() {
 	let f = "./mockdocfhir.adm";
-	let url: string = "https://github.com/atlasmap/atlasmap/raw/master/ui/test-resources/adm/mockdocfhir.adm";
+	let tagName: string = generateGitHubTagName();
+	let url: string = "https://github.com/atlasmap/atlasmap/raw/" + tagName + "/ui/test-resources/adm/mockdocfhir.adm";
 	let FetchStream = require("fetch").FetchStream;
 	let out = fs.createWriteStream(f);
 	new FetchStream(url).pipe(out);
 	return uri2path(fileUrl(f));
+}
+
+function generateGitHubTagName(): string {
+	return "atlasmap-" + ATLASMAP_SERVER_VERSION;
 }
 
 export function createBrokenADM() {

--- a/src/test/command.test.utils.ts
+++ b/src/test/command.test.utils.ts
@@ -9,6 +9,9 @@ import * as vscode from "vscode";
 import AtlasMapPanel from '../atlasMapWebView';
 
 const request = require("request");
+const fileUrl = require('file-url');
+const uri2path = require('file-uri-to-path');
+const fs = require("fs");
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -46,9 +49,10 @@ export function determineUsedPort(spy: sinon.SinonSpy): string {
 	return undefined;
 }
 
-export function startAtlasMapInstance(infoSpy: sinon.SinonSpy, spawnSpy: sinon.SinonSpy): Promise<string> {
+export function startAtlasMapInstance(infoSpy: sinon.SinonSpy, spawnSpy: sinon.SinonSpy, context: any = undefined): Promise<string> {
 	return new Promise<string>(async (resolve, reject) => {
-		await vscode.commands.executeCommand("atlasmap.start");
+		
+		await vscode.commands.executeCommand("atlasmap.start", context);
 		
 		let waitTime = 0;
 		let _port = determineUsedPort(infoSpy);
@@ -156,4 +160,24 @@ export function createExecuteCommandStubFakingExternalOpenBrowserCall() {
 		});
 	executeCommandStub.callThrough();
 	return executeCommandStub;
+}
+
+export function downloadTestADM() {
+	let f = "./mockdocfhir.adm";
+	let url: string = "https://github.com/atlasmap/atlasmap/raw/master/ui/test-resources/adm/mockdocfhir.adm";
+	let FetchStream = require("fetch").FetchStream;
+	let out = fs.createWriteStream(f);
+	new FetchStream(url).pipe(out);
+	return uri2path(fileUrl(f));
+}
+
+export function createBrokenADM() {
+	let f = "./mockdoccorrupted.adm";
+	fs.writeFile(f, "someBrokenADMContent", function(err) {
+		if(err) {
+			return console.log(err);
+		}
+	});
+	
+	return uri2path(fileUrl(f));
 }


### PR DESCRIPTION
Signed-off-by: Lars Heinemann <lhein.smx@gmail.com>

This PR will make the Open AtlasMap an action on a ADM file in the explorer view. When executed it will pass the path of the adm file as `-Datlasmap.adm.path=<path>` to the startup of the atlasmap-standalone. 

For now I am not able to test if the file gets imported in AtlasMap correctly because https://github.com/atlasmap/atlasmap/issues/755 is still not implemented.

@pleacu @igarashitm FYI

fixes #7 
