### PR TITLE
Override padding style from VS Code to match AtlasMap one #69

### DIFF
--- a/src/atlasMapWebView.ts
+++ b/src/atlasMapWebView.ts
@@ -84,8 +84,9 @@ export default class AtlasMapPanel {
 		fetchUrl(url, function(error, meta, body) {
 			try {
 				var content =  body.toString();
-				content = body.toString().replace('href="/"', 'href="'+url+'/"');
-				AtlasMapPanel.currentPanel._panel.webview.html = content;
+				var contentWithHrefFullySpecified = content.replace('href="/"', 'href="'+url+'/"');
+				var contentWithHrefFullySpecifiedAndCSS = contentWithHrefFullySpecified.replace('<body>', '<body style="padding: 0">');
+				AtlasMapPanel.currentPanel._panel.webview.html = contentWithHrefFullySpecifiedAndCSS;
 			} catch (err) {
 				console.error(err);
 			}

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -1,11 +1,13 @@
 "use strict";
 
+import * as atlasMapWebView from "../atlasMapWebView";
 import * as chai from "chai";
 import * as child_process from 'child_process';
 import * as sinon from "sinon";
 import * as sinonChai from "sinon-chai";
 import * as testUtils from "./command.test.utils";
 import * as vscode from "vscode";
+import { BrowserType } from "../utils";
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -116,6 +118,9 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 					await testUtils.getWebUI(url)
 						.then( (body) => {
 							expect(body, "Unexpected html response body").to.contain("AtlasMap");
+							if (browserConfig === BrowserType.Internal) {
+								expect(atlasMapWebView.default.currentPanel._panel.webview.html).to.contain(url).and.to.contain('<body style="padding: 0">');
+							}
 							done();
 						})
 						.catch( (err) => {


### PR DESCRIPTION
it allows to take the whole space in UI

Signed-off-by: Aurélien Pupier <apupier@redhat.com>