### PR TITLE
Use VS Code command to open AtlasMap UI #86

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1629,8 +1629,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1651,14 +1650,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1673,20 +1670,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1803,8 +1797,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1816,7 +1809,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1831,7 +1823,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1839,14 +1830,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -1865,7 +1854,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1946,8 +1934,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1959,7 +1946,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2045,8 +2031,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2082,7 +2067,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2102,7 +2086,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2146,14 +2129,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -3007,11 +2988,6 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
 		},
-		"is-wsl": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-		},
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3735,14 +3711,6 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
-			}
-		},
-		"opn": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-			"integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
-			"requires": {
-				"is-wsl": "^1.1.0"
 			}
 		},
 		"ordered-read-streams": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 					"enum": [
 						"Internal",
 						"External (Default OS Browser)"
-					],					
+					],
 					"default": "External (Default OS Browser)",
 					"description": "Select the preferred browser type to open AtlasMap UI in."
 				}
@@ -86,7 +86,6 @@
 		"expand-home-dir": "^0.0.3",
 		"fetch": "^1.1.0",
 		"find-java-home": "^0.2.0",
-		"opn": "^5.4.0",
 		"path": "^0.12.7",
 		"path-exists": "^3.0.0",
 		"util": "^0.11.1"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,6 @@
 
 import * as atlasMapWebView from './atlasMapWebView';
 import * as child_process from 'child_process';
-import * as opn from 'opn';
 import * as path from 'path';
 import * as requirements from './requirements';
 import { TextDecoder } from 'util';
@@ -122,6 +121,6 @@ function openURL(url: string) {
 	if (utils.isUsingInternalView()) {
 		atlasMapWebView.default.createOrShow(url);		
 	} else {
-		opn(url);
+		vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
 	}	
 }

--- a/src/test/command.combined.test.ts
+++ b/src/test/command.combined.test.ts
@@ -14,7 +14,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 	describe("Combined Start Stop Commands Tests with browser type: " + browserConfig, function() {
 
 		let sandbox: sinon.SinonSandbox;
-		let executeCommandSpy: sinon.SinonSpy;
+		let executeCommandStub: sinon.SinonStub;
 		let showInformationMessageSpy: sinon.SinonSpy;
 		let createOutputChannelSpy: sinon.SinonSpy;
 		let spawnChildProcessSpy: sinon.SinonSpy;
@@ -22,19 +22,23 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 
 		before(function() {
 			sandbox = sinon.createSandbox();
-			executeCommandSpy = sinon.spy(vscode.commands, "executeCommand");
 			showInformationMessageSpy = sinon.spy(vscode.window, "showInformationMessage");
 			createOutputChannelSpy = sinon.spy(vscode.window, "createOutputChannel");
 			spawnChildProcessSpy = sinon.spy(child_process, "spawn");
+			executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+			executeCommandStub.withArgs('vscode.open', sinon.match.any).callsFake((args) => {
+				console.log("vscode.open called, it is stubbed with a no-op. I was called with arguments:" + args);
+			});
+			executeCommandStub.callThrough();
 			testUtils.switchSettingsToType(browserConfig);
 		});
 
 		after(function() {
-			executeCommandSpy.restore();
 			showInformationMessageSpy.restore();
 			createOutputChannelSpy.restore();
 			spawnChildProcessSpy.restore();
 			sandbox.restore();
+			executeCommandStub.restore();
 			port =  undefined;
 			testUtils.switchSettingsToType(undefined);
 		});
@@ -42,7 +46,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 		afterEach(function(done) {
 			testUtils.stopAtlasMapInstance(port, showInformationMessageSpy)
 				.then( () => {
-					executeCommandSpy.resetHistory();
+					executeCommandStub.resetHistory();
 					showInformationMessageSpy.resetHistory();
 					createOutputChannelSpy.resetHistory();
 					spawnChildProcessSpy.resetHistory();
@@ -60,7 +64,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 			expect(port).to.be.undefined;
 			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)
 				.then( (_port) => {
-					expect(executeCommandSpy.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
 					port = _port;
 					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
 					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
@@ -77,7 +81,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 
 							testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)
 								.then( (_port) => {
-									expect(executeCommandSpy.withArgs("atlasmap.start").calledTwice, "AtlasMap start command was not issued").to.be.true;
+									expect(executeCommandStub.withArgs("atlasmap.start").calledTwice, "AtlasMap start command was not issued").to.be.true;
 									port = _port;
 									expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
 									expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -14,7 +14,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 	describe("Start AtlasMap Command Tests with browser type: " + browserConfig, function() {
 
 		let sandbox: sinon.SinonSandbox;
-		let executeCommandSpy: sinon.SinonSpy;
+		let executeCommandStub: sinon.SinonStub;
 		let showInformationMessageSpy: sinon.SinonSpy;
 		let createOutputChannelSpy: sinon.SinonSpy;
 		let spawnChildProcessSpy: sinon.SinonSpy;
@@ -22,7 +22,11 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 
 		before(function() {
 			sandbox = sinon.createSandbox();
-			executeCommandSpy = sinon.spy(vscode.commands, "executeCommand");
+			executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+			executeCommandStub.withArgs('vscode.open', sinon.match.any).callsFake((args) => {
+				console.log("vscode.open called, it is stubbed with a no-op. I was called with arguments:" + args);
+			});
+			executeCommandStub.callThrough();
 			showInformationMessageSpy = sinon.spy(vscode.window, "showInformationMessage");
 			createOutputChannelSpy = sinon.spy(vscode.window, "createOutputChannel");
 			spawnChildProcessSpy = sinon.spy(child_process, "spawn");
@@ -30,7 +34,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 		});
 
 		after(function() {
-			executeCommandSpy.restore();
+			executeCommandStub.restore();
 			showInformationMessageSpy.restore();
 			createOutputChannelSpy.restore();
 			spawnChildProcessSpy.restore();
@@ -42,7 +46,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 		afterEach(function(done) {
 			testUtils.stopAtlasMapInstance(port, showInformationMessageSpy)
 				.then( () => {
-					executeCommandSpy.resetHistory();
+					executeCommandStub.resetHistory();
 					showInformationMessageSpy.resetHistory();
 					createOutputChannelSpy.resetHistory();
 					spawnChildProcessSpy.resetHistory();
@@ -60,7 +64,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 			expect(port).to.be.undefined;
 			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)
 				.then( _port => {
-					expect(executeCommandSpy.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
 					port = _port;
 					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
 					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
@@ -77,18 +81,18 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 			expect(port).to.be.undefined;
 			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)
 				.then( async (_port) => {
-					expect(executeCommandSpy.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
 					port = _port;
 					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
 					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
 					expect(createOutputChannelSpy.calledOnce);
 
 					await vscode.commands.executeCommand("atlasmap.start");
-					expect(executeCommandSpy.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(1);
+					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(1);
 					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
 		
 					await vscode.commands.executeCommand("atlasmap.start");
-					expect(executeCommandSpy.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(2);
+					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(2);
 					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
 		
 					// wait a bit for the web ui  to be ready - not nice but works fine
@@ -106,7 +110,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 			expect(port).to.be.undefined;
 			testUtils.startAtlasMapInstance(showInformationMessageSpy, spawnChildProcessSpy)
 				.then( async (_port) => {
-					expect(executeCommandSpy.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
 					port = _port;
 					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
 					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;


### PR DESCRIPTION
instead of opn external library


I discovered that VS Code is providing a command which is handling opening an URL in default system browser. It might be more performant than the opn library.