### PR TITLE
Update contributing guide

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -16,7 +16,14 @@
 * Select *Run AtlasMap extension*
 * Click on the green arrow OR press *F5* to launch the extension
 
-When testing new version of the AtlasMap, just replace the jar in *./jars* folder respecting the name *atlasmap-standalone.jar* or launch it separately on port *8585*.
+When testing new version of the AtlasMap, just replace the jar in *./jars* folder respecting the name *atlasmap-standalone.jar* and relaunch the *Run AtlasMap extension*.
+
+## Debug the Webview API
+
+After calling the "Open AtlasMap" and that the AtlasMap panel is opened, some commands to debug are available in the same VS Code instance you launched the "Open AtlasMap command":
+
+* in palette (Ctrl+Shift+P), use "Developer: Open Webview Developer Tools"
+* to have the console and some stack you will need to call from the palette (Ctrl+Shift+P) "Developer: Reload Web
 
 ## How to provide a new version on VS Code Marketplace
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Possible choices:
 "AtlasMap: Open AtlasMap" command is starting a local AtlasMap instance and opens a Web View or an external browser pointing to its web UI:
 ![Open AtlasMap command in palette](doc/OpenAtlasMapCommand.png)
 
-AtlasMap is started on port 8585 by default. If this port is occupied another free port will be choosen automatically.
+AtlasMap is started on port 8585 by default. If this port is occupied another free port will be chosen automatically.
 To check if it has been started correctly, you can go to Output view and check for the "AtlasMap Server" output:
 ![AtlasMap Server output](doc/AtlasMapServerOutput.png)
 


### PR DESCRIPTION
- remove information that we can use an external AtlasMap server as it
is no more the case
- add information to debug the VS Code WebView

Signed-off-by: Aurélien Pupier <apupier@redhat.com>