### PR TITLE
Support log with any kind of parameter #112

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -240,7 +240,7 @@ export function log(text) {
 	if (!atlasMapExtensionOutputChannel) {
 		atlasMapExtensionOutputChannel = vscode.window.createOutputChannel("AtlasMap Extension");
 	}
-	atlasMapExtensionOutputChannel.append(text);
+	atlasMapExtensionOutputChannel.append(text.toString());
 }
 
 /* Used for testing purpose only*/


### PR DESCRIPTION
so now we can call the log with an Error object.
it avoids this error: "stack trace: TypeError [ERR_INVALID_ARG_TYPE]:
The first argument must be one of type string, Buffer, ArrayBuffer,
Array, or Array-like Object. Received type object"

Signed-off-by: Aurélien Pupier <apupier@redhat.com>