### PR TITLE
Check panel still available when accesing it #112

### DIFF
--- a/src/atlasMapWebView.ts
+++ b/src/atlasMapWebView.ts
@@ -93,7 +93,9 @@ export default class AtlasMapPanel {
 				var content =  body.toString();
 				var contentWithHrefFullySpecified = content.replace('href="/"', 'href="'+url+'/"');
 				var contentWithHrefFullySpecifiedAndCSS = contentWithHrefFullySpecified.replace('<body>', '<body style="padding: 0">');
-				AtlasMapPanel.currentPanel._panel.webview.html = contentWithHrefFullySpecifiedAndCSS;
+				if (AtlasMapPanel.currentPanel) {
+					AtlasMapPanel.currentPanel._panel.webview.html = contentWithHrefFullySpecifiedAndCSS;
+				}
 			} catch (err) {
 				log(err);
 			}


### PR DESCRIPTION
in case, a dispose of the view has been called before it has fully
loaded, there can be an error. It happens in test "Combined Start Stop
Commands Tests with browser type:" with a better conditional wait

Signed-off-by: Aurélien Pupier <apupier@redhat.com>