### PR TITLE
FUSETOOLS2-44 : stop AtlasMap instance when VS Code extension deactivate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## 0.0.4
 
 - Upgrade to AtlasMap 1.42.10
+- Fix resource leak when closing VS Code on Mac
 
 ## 0.0.3
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,10 @@ import * as vscode from 'vscode';
 
 let atlasMapExtensionOutputChannel: vscode.OutputChannel;
 let atlasMapServerOutputChannel: vscode.OutputChannel;
-let atlasMapProcess: child_process.ChildProcess;
-let atlasMapLaunchPort: string;
+/*Export for test purpose*/
+export let atlasMapProcess: child_process.ChildProcess;
+/*Export for test purpose*/
+export let atlasMapLaunchPort: string;
 export let atlasMapUIReady: boolean;
 let admFilePath: string;
 let storagePath: string;
@@ -84,6 +86,12 @@ export function activate(context: vscode.ExtensionContext) {
 			handleStopAtlasMap();
 		}
 	}));
+}
+
+export function deactivate(context: vscode.ExtensionContext) {
+	if (isAtlasMapRunning()) {
+		stopLocalAtlasMapInstance();
+	}
 }
 
 function isAtlasMapRunning(): boolean {

--- a/src/test/ActivateDeactivateExtension.test.ts
+++ b/src/test/ActivateDeactivateExtension.test.ts
@@ -1,0 +1,45 @@
+import * as chai from "chai";
+import * as extension from "../extension";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+import * as testUtils from "./command.test.utils";
+import * as vscode from "vscode";
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe("Ensure Atlasmap shutdowned on extension deactivation", function () {
+
+	let sandbox: sinon.SinonSandbox;
+	let showInformationMessageSpy: sinon.SinonSpy;
+
+	beforeEach(function () {
+		sandbox = sinon.createSandbox();
+		showInformationMessageSpy = sinon.spy(vscode.window, "showInformationMessage");
+	});
+
+	afterEach(function () {
+		showInformationMessageSpy.restore();
+		sandbox.restore();
+		vscode.extensions.getExtension('redhat.atlasmap-viewer').activate();
+	});
+
+	it("Test started instance stopped on deactivation", function (done) {
+		testUtils.startAtlasMapInstance(showInformationMessageSpy).then(() => {
+			let atlasMapProcess = extension.atlasMapProcess;
+			expect(atlasMapProcess.killed).to.be.false;
+			extension.deactivate(null);
+			expect(atlasMapProcess.killed).to.be.true;
+			done();
+		}).catch((error) => {
+			done(error);
+		}).finally(() => {
+			testUtils.stopAtlasMapInstance(extension.atlasMapLaunchPort, showInformationMessageSpy);
+		});
+	});
+
+	it("Test deactivate doesn't cause trouble when no AtlasMap instance launched", function (done) {
+		extension.deactivate(null);
+		done();
+	});
+});

--- a/src/test/ActivateDeactivateExtension.test.ts
+++ b/src/test/ActivateDeactivateExtension.test.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 const expect = chai.expect;
 chai.use(sinonChai);
 
-describe("Ensure Atlasmap shutdowned on extension deactivation", function () {
+describe("Ensure Atlasmap is shut down upon extension deactivation", function () {
 
 	let sandbox: sinon.SinonSandbox;
 	let showInformationMessageSpy: sinon.SinonSpy;
@@ -24,7 +24,7 @@ describe("Ensure Atlasmap shutdowned on extension deactivation", function () {
 		vscode.extensions.getExtension('redhat.atlasmap-viewer').activate();
 	});
 
-	it("Test started instance stopped on deactivation", function (done) {
+	it("Test that the running instance is stopped on deactivation", function (done) {
 		testUtils.startAtlasMapInstance(showInformationMessageSpy).then(() => {
 			let atlasMapProcess = extension.atlasMapProcess;
 			expect(atlasMapProcess.killed).to.be.false;


### PR DESCRIPTION
Notably, it deactivates when VS Code shutdowns. it avoids to have a
resource leaks of AtlasMap instance on Mac.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>