### PR TITLE
FUSETOOLS2-45 - retain context of webview

### DIFF
--- a/src/atlasMapWebView.ts
+++ b/src/atlasMapWebView.ts
@@ -26,7 +26,8 @@ export default class AtlasMapPanel {
 
 		// Otherwise, create a new panel.
 		const panel = vscode.window.createWebviewPanel(AtlasMapPanel.viewType, "AtlasMap", column || vscode.ViewColumn.One, {
-			enableScripts: true
+			enableScripts: true,
+			retainContextWhenHidden: true
 		});
 
 		AtlasMapPanel.currentPanel = new AtlasMapPanel(panel, url);


### PR DESCRIPTION
it avoids to call a refresh when switching between tabs and getting back
to the webview. Consequently, it avoids some latency and most important
it workarounds a bug inside AtlasMap
https://github.com/atlasmap/atlasmap/issues/1455

the drawback is that the memory is still kept when the tab is hidden.
Given that for now we can open a single tab at a time, this is not a
major problem.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>