### PR TITLE
FUSETOOLS2-80 - fix Jenkins packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ node('rhel7'){
 	stage('Package') {
         def packageJson = readJSON file: 'package.json'
         sh "vsce package -o vscode-atlasmap-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
-        sh "npm pack && mv vscode-atlasmap-${packageJson.version}.tgz vscode-atlasmap-${packageJson.version}-${env.BUILD_NUMBER}.tgz"
+        sh "npm pack && mv atlasmap-viewer-${packageJson.version}.tgz vscode-atlasmap-${packageJson.version}-${env.BUILD_NUMBER}.tgz"
 	}
 
 	if(params.UPLOAD_LOCATION) {


### PR DESCRIPTION
this extension has a different pattern for naming for historical
reasons. It requires then to adjust the packaging steps.
For the sake of consistency with other extensions, keeping the
vscode-atlasmap-xx naming for the output

it si fixing current master build failure https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/VS%20Code/job/vscode-atlasmap-release/101/console

```
+ mv vscode-atlasmap-0.0.5.tgz vscode-atlasmap-0.0.5-101.tgz
mv: cannot stat ‘vscode-atlasmap-0.0.5.tgz’: No such file or directory
```