### PR TITLE
Load Atlasmap directly in the webview

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"icon": "icons/icon128.png",
 	"preview": true,
 	"config": {
-		"atlasmapversion": "1.43.4"
+		"atlasmapversion": "2.0.3"
 	},
 	"bugs": "https://github.com/jboss-fuse/vscode-atlasmap/issues",
 	"homepage": "https://github.com/jboss-fuse/vscode-atlasmap",

--- a/src/AtlasMapPanel.ts
+++ b/src/AtlasMapPanel.ts
@@ -114,6 +114,7 @@ export default class AtlasMapPanel {
 					http-equiv="Content-Security-Policy"
 					content="
 						default-src 'self' 'unsafe-inline' 'unsafe-hashes' 'unsafe-eval' ${fullWebServerUri} ${cspSource};
+						img-src 'self' ${fullWebServerUri} ${cspSource} data:;
 					" />
 			`;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 		if (isAtlasMapRunning() && admFilePath === undefined && (ctx === undefined || ctx.fsPath === undefined)) {
 			// no need to start another atlasmap instance - just open it again
 			vscode.window.showInformationMessage("Running AtlasMap instance found at port " + atlasMapLaunchPort);
-			openURL(generateUrl(atlasMapLaunchPort));
+			openURL(generateUrl(atlasMapLaunchPort), context);
 			return;
 		}
 
@@ -58,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
 				if (doLaunch) {
 					utils.retrieveFreeLocalPort()
 					.then( (port) => {
-						launchAtlasMapLocally(atlasmapExecutablePath, port, localAdmFile)
+						launchAtlasMapLocally(context, atlasmapExecutablePath, port, localAdmFile)
 							.then( () => {
 								vscode.window.showInformationMessage("Starting AtlasMap instance at port " + port);
 								atlasMapLaunchPort = port;
@@ -142,7 +142,7 @@ function handleStopAtlasMap() {
 		});
 }
 
-function launchAtlasMapLocally(atlasmapExecutablePath: string, port: string, admFilePath: string = ""): Promise<any> {
+function launchAtlasMapLocally(context: vscode.ExtensionContext, atlasmapExecutablePath: string, port: string, admFilePath: string = ""): Promise<any>{
 	return new Promise( (resolve, reject) => {
 		showProgressInfo(port);
 		process.env.SERVER_PORT = port;
@@ -180,7 +180,7 @@ function launchAtlasMapLocally(atlasmapExecutablePath: string, port: string, adm
 					atlasMapServerOutputChannel.append(text);
 					if (text.indexOf("### AtlasMap Data Mapper UI started") > 0) {
 						const url = generateUrl(port);
-						openURL(url);
+						openURL(url, context);
 						atlasMapUIReady = true;
 					}
 				});
@@ -216,9 +216,9 @@ function stopLocalAtlasMapInstance(): Promise<boolean> {
 	});	
 }
 
-function openURL(url: string) {
+function openURL(url: string, context: vscode.ExtensionContext) {
 	if (utils.isUsingInternalView()) {
-		atlasMapWebView.default.createOrShow(url);		
+		atlasMapWebView.default.createOrShow(url, context);		
 	} else {
 		vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
 	}	

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -57,7 +57,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 				fs.unlink(testADMFileBroken, (err) => {
 					if (err) throw err;
 				});
-			}			
+			}
 		});
 
 		afterEach(function(done) {
@@ -214,7 +214,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 								expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
 								expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
 								expect(createOutputChannelSpy.calledTwice);
-			
+
 								let url:string = "http://localhost:" + port;
 								await testUtils.getWebUI(url)
 									.then( (body) => {
@@ -282,6 +282,6 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 
 
 function checkBorderStyleAvailable() {
-	expect(atlasMapWebView.default.currentPanel._panel.webview.html, "HTML doesn't contain url the zero border size").to.contain('style="border:0"');
+	expect(atlasMapWebView.default.currentPanel._panel.webview.html, "HTML doesn't contain url the <title>AtlasMap Data Mapper UI</title>").to.contain('<title>AtlasMap Data Mapper UI</title>');
 }
 


### PR DESCRIPTION
It looks like iframes inside a webview are buggy/limited. This loads
Atlasmap directly inside the webview skipping the iframe step.

Fixes #371