### PR TITLE
FUSETOOLS2-469 - have deterministic test checking for AtlasMap opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -561,6 +561,12 @@
 				"async-done": "^1.2.2"
 			}
 		},
+		"async-wait-until": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/async-wait-until/-/async-wait-until-1.2.4.tgz",
+			"integrity": "sha512-H7ZR3cu1THxrJiDgevu+PgbyT0o5P/9nsCZj70ckruJCMWt/UOQmGo65wKWvEQN69MJk140x5/Z01ZQjzfwyOw==",
+			"dev": true
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"@types/sinon-chai": "^3.2.4",
 		"@types/vscode": "^1.45.1",
 		"assert": "^2.0.0",
+		"async-wait-until": "^1.2.4",
 		"chai": "^4.2.0",
 		"download": "^8.0.0",
 		"file-uri-to-path": "^2.0.0",

--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -13,6 +13,7 @@ import { RESTART_CHOICE, WARN_MSG } from '../extension';
 
 const expect = chai.expect;
 chai.use(sinonChai);
+const waitUntil = require('async-wait-until');
 
 testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 	describe("Start AtlasMap Command Tests with browser type: " + browserConfig, function() {
@@ -138,7 +139,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 						.then( (body) => {
 							expect(body, "Unexpected html response body").to.contain("AtlasMap");
 							if (browserConfig === BrowserType.Internal) {
-								checkBorderStyleAvailable();
+								checkContainsAtlasMapTitle();
 							}
 							done();
 						})
@@ -170,7 +171,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 						.then( (body) => {
 							expect(body, "Unexpected html response body").to.contain("AtlasMap");
 							if (browserConfig === BrowserType.Internal) {
-								checkBorderStyleAvailable();
+								checkContainsAtlasMapTitle();
 							}
 							done();
 						})
@@ -202,7 +203,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 						.then( (body) => {
 							expect(body, "Unexpected html response body").to.contain("AtlasMap");
 							if (browserConfig === BrowserType.Internal) {
-								checkBorderStyleAvailable();
+								checkContainsAtlasMapTitle();
 							}
 
 
@@ -220,7 +221,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 									.then( (body) => {
 										expect(body, "Unexpected html response body").to.contain("AtlasMap");
 										if (browserConfig === BrowserType.Internal) {
-											checkBorderStyleAvailable();
+											checkContainsAtlasMapTitle();
 										}
 										done();
 									})
@@ -262,7 +263,7 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 						.then( (body) => {
 							expect(body, "Unexpected html response body").to.contain("AtlasMap");
 							if (browserConfig === BrowserType.Internal) {
-								checkBorderStyleAvailable();
+								checkContainsAtlasMapTitle();
 							}
 							done();
 						})
@@ -280,8 +281,10 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 	});
 });
 
-
-function checkBorderStyleAvailable() {
-	expect(atlasMapWebView.default.currentPanel._panel.webview.html, "HTML doesn't contain url the <title>AtlasMap Data Mapper UI</title>").to.contain('<title>AtlasMap Data Mapper UI</title>');
+function checkContainsAtlasMapTitle() {
+	const expectedAtlasMapTitle = '<title>AtlasMap Data Mapper UI</title>';
+	waitUntil(() => atlasMapWebView.default.currentPanel._panel.webview.html.includes(expectedAtlasMapTitle));
+	expect(
+		atlasMapWebView.default.currentPanel._panel.webview.html,
+		`HTML doesn't contain url the ${expectedAtlasMapTitle}`).to.contain(expectedAtlasMapTitle);
 }
-


### PR DESCRIPTION
now that the content of index.html is retrieve dynamically, we need to
provide a conditional wait in tests to ensure that it had time to load
the content of AtlasMap UI

Signed-off-by: Aurélien Pupier <apupier@redhat.com>