### PR TITLE
FUSETOOLS2-490 - use rhel8 instead of rhel7 for Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
 	stage('Checkout repo') {
 		deleteDir()
 		git url: 'https://github.com/jboss-fuse/vscode-atlasmap'
@@ -48,7 +48,7 @@ node('rhel7'){
     }
 }
 
-node('rhel7'){
+node('rhel8'){
 	if(publishToMarketPlace.equals('true')){
 		timeout(time:5, unit:'DAYS') {
 			input message:'Approve deployment?', submitter: 'apupier,lheinema,bfitzpat,tsedmik,djelinek'


### PR DESCRIPTION
to workaround https://github.com/microsoft/vscode/issues/99492

Signed-off-by: Aurélien Pupier <apupier@redhat.com>