### PR TITLE
FUSETOOLS2-702 - use npm ci instead of npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - 'npm install -g typescript'
   - 'npm install -g vsce'
 install:
-  - 'npm install'
+  - 'npm ci'
   # https://github.com/travis-ci/travis-ci/issues/8813
   - 'rm -f ./node_modules/.bin/which'
   - 'vsce package'
@@ -21,7 +21,7 @@ after_success:
     fi
 cache:
   directories:
-    - "node_modules"
+    - "$HOME/.npm"
 env: DISPLAY=:99
 branches:
   except:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node('rhel8'){
 		env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
 		sh "java -version"
 		
-		sh "npm install"
+		sh "npm ci"
 		sh "npm run vscode:prepublish"
 	}
 


### PR DESCRIPTION
it allows to ensure that the package-lock.json is respected

Signed-off-by: Aurélien Pupier <apupier@redhat.com>