### PR TITLE
Fusetools2 672 fix master on jenkins

### DIFF
--- a/src/test/command.start.test.ts
+++ b/src/test/command.start.test.ts
@@ -78,83 +78,52 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 				});
 		});
 
-		it("Test Start Command invocation without running AtlasMap instance", function(done) {
+		it("Test Start Command invocation without running AtlasMap instance", async() => {
 			expect(port).to.be.undefined;
-			testUtils.startAtlasMapInstance(showInformationMessageSpy)
-				.then( _port => {
-					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
-					port = _port;
-					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
-					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
-					expect(createOutputChannelSpy.calledOnce);
-					done();
-				})
-				.catch( err => {
-					console.error(err);
-					done(err);
-				});
+			port = await testUtils.startAtlasMapInstance(showInformationMessageSpy);
+			expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+			expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+			expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+			expect(createOutputChannelSpy.calledOnce);
 		});
 
-		it("Test Start Command invocation with running AtlasMap instance (DO NOT SPAWN MORE THAN ONE ATLASMAP)", function(done) {
+		it("Test Start Command invocation with running AtlasMap instance (DO NOT SPAWN MORE THAN ONE ATLASMAP)", async() => {
 			expect(port).to.be.undefined;
-			testUtils.startAtlasMapInstance(showInformationMessageSpy)
-				.then( async (_port) => {
-					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
-					port = _port;
-					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
-					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
-					expect(createOutputChannelSpy.calledOnce);
+			port = await testUtils.startAtlasMapInstance(showInformationMessageSpy);
+			expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+			expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+			expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+			expect(createOutputChannelSpy.calledOnce);
 
-					await vscode.commands.executeCommand("atlasmap.start");
-					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(1);
-					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
+			await vscode.commands.executeCommand("atlasmap.start");
+			expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(1);
+			expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
 
-					await vscode.commands.executeCommand("atlasmap.start");
-					expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(2);
-					expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
+			await vscode.commands.executeCommand("atlasmap.start");
+			expect(executeCommandStub.withArgs("atlasmap.start").callCount, "AtlasMap start command was not issued").to.be.greaterThan(2);
+			expect(showInformationMessageSpy.getCalls()[showInformationMessageSpy.callCount-1].args[0], "No detection message for running instance found!").to.equal("Running AtlasMap instance found at port " + port);
 
-					// wait a bit for the web ui  to be ready - not nice but works fine
-					await new Promise(resolve => setTimeout(resolve, 3000));
-
-					done();
-				})
-				.catch( err => {
-					console.error(err);
-					done(err);
-				});
+			// wait a bit for the web ui  to be ready - not nice but works fine
+			await new Promise(resolve => setTimeout(resolve, 3000));
 		});
 
-		it("Test Web UI availability after startup of server", function(done) {
+		it("Test Web UI availability after startup of server", async() => {
 			expect(port).to.be.undefined;
-			testUtils.startAtlasMapInstance(showInformationMessageSpy)
-				.then( async (_port) => {
-					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
-					port = _port;
-					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
-					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
-					expect(createOutputChannelSpy.calledOnce);
+			port = await testUtils.startAtlasMapInstance(showInformationMessageSpy);
+			expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+			expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+			expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+			expect(createOutputChannelSpy.calledOnce);
 
-					let url:string = "http://localhost:" + port;
-					await testUtils.getWebUI(url)
-						.then( (body) => {
-							expect(body, "Unexpected html response body").to.contain("AtlasMap");
-							if (browserConfig === BrowserType.Internal) {
-								checkContainsAtlasMapTitle();
-							}
-							done();
-						})
-						.catch( (err) => {
-							console.error(err);
-							done(err);
-						});
-				})
-				.catch( err => {
-					console.error(err);
-					done(err);
-				});
+			const url: string = "http://localhost:" + port;
+			const body: string = await testUtils.getWebUI(url);
+			expect(body, "Unexpected html response body").to.contain("AtlasMap");
+			if (browserConfig === BrowserType.Internal) {
+				await checkContainsAtlasMapTitle();
+			}
 		});
 
-		it("Test import of ADM file with stopped server", async function() {
+		it("Test import of ADM file with stopped server", async() => {
 			expect(port).to.be.undefined;
 			expect(testADMFileWorking, "Unable to download the tagged test adm file from " + testUtils.generateGithubDownloadUrl()).to.not.be.undefined;
 			const context = { fsPath: testADMFileWorking };
@@ -168,109 +137,67 @@ testUtils.BROWSER_TYPES.forEach(function (browserConfig) {
 			const body: string = await testUtils.getWebUI(url);
 			expect(body, "Unexpected html response body").to.contain("AtlasMap");
 			if (browserConfig === BrowserType.Internal) {
-				checkContainsAtlasMapTitle();
+				await checkContainsAtlasMapTitle();
 			}
 		});
 
-		it("Test import of ADM file with running server", function(done) {
+		it("Test import of ADM file with running server", async() => {
 			expect(port).to.be.undefined;
 			expect(testADMFileWorking, "Unable to download the tagged test adm file from " + testUtils.generateGithubDownloadUrl()).to.not.be.undefined;
-			let context = { fsPath: testADMFileWorking };
-			testUtils.startAtlasMapInstance(showInformationMessageSpy, context)
-				.then( async (_port) => {
-					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
-					port = _port;
-					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
-					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
-					expect(createOutputChannelSpy.calledOnce);
+			const context = { fsPath: testADMFileWorking };
+			port = await testUtils.startAtlasMapInstance(showInformationMessageSpy, context);
+			expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+			expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+			expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+			expect(createOutputChannelSpy.calledOnce);
 
-					let url:string = "http://localhost:" + port;
-					await testUtils.getWebUI(url)
-						.then( (body) => {
-							expect(body, "Unexpected html response body").to.contain("AtlasMap");
-							if (browserConfig === BrowserType.Internal) {
-								checkContainsAtlasMapTitle();
-							}
+			let url:string = "http://localhost:" + port;
+			const body: string = await testUtils.getWebUI(url);
+			expect(body, "Unexpected html response body").to.contain("AtlasMap");
+			if (browserConfig === BrowserType.Internal) {
+				await checkContainsAtlasMapTitle();
+			}
 
+			port = await testUtils.startAtlasMapInstance(showInformationMessageSpy, context);
+			expect(showWarningMessageStub.withArgs(WARN_MSG).calledOnce, "There was no warning dialog shown when starting another instance with an ADM import specified.").to.be.true;
+			expect(executeCommandStub.withArgs("atlasmap.start").calledTwice, "AtlasMap start command was not issued").to.be.true;
+			expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+			expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+			expect(createOutputChannelSpy.calledTwice);
 
-							testUtils.startAtlasMapInstance(showInformationMessageSpy, context)
-							.then( async (_port) => {
-								expect(showWarningMessageStub.withArgs(WARN_MSG).calledOnce, "There was no warning dialog shown when starting another instance with an ADM import specified.").to.be.true;
-								expect(executeCommandStub.withArgs("atlasmap.start").calledTwice, "AtlasMap start command was not issued").to.be.true;
-								port = _port;
-								expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
-								expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
-								expect(createOutputChannelSpy.calledTwice);
-
-								let url:string = "http://localhost:" + port;
-								await testUtils.getWebUI(url)
-									.then( (body) => {
-										expect(body, "Unexpected html response body").to.contain("AtlasMap");
-										if (browserConfig === BrowserType.Internal) {
-											checkContainsAtlasMapTitle();
-										}
-										done();
-									})
-									.catch( (err) => {
-										console.error(err);
-										done(err);
-									});
-							})
-							.catch( err => {
-								console.error(err);
-								done(err);
-							});
-						})
-						.catch( (err) => {
-							console.error(err);
-							done(err);
-						});
-				})
-				.catch( err => {
-					console.error(err);
-					done(err);
-				});
+			url = "http://localhost:" + port;
+			const bodyOnSecondCall = await testUtils.getWebUI(url);
+			expect(bodyOnSecondCall, "Unexpected html response body").to.contain("AtlasMap");
+			if (browserConfig === BrowserType.Internal) {
+				await checkContainsAtlasMapTitle();
+			}
 		});
 
-		it("Test import of corrupted ADM file with stopped server", function(done) {
+		it("Test import of corrupted ADM file with stopped server", async() => {
 			expect(port).to.be.undefined;
 			expect(testADMFileBroken).to.not.be.undefined;
-			let context = { fsPath: testADMFileBroken };
-			testUtils.startAtlasMapInstance(showInformationMessageSpy, context)
-				.then( async (_port) => {
-					expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
-					port = _port;
-					expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
-					expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
-					expect(createOutputChannelSpy.calledOnce);
+			const context = { fsPath: testADMFileBroken };
+			port = await testUtils.startAtlasMapInstance(showInformationMessageSpy, context);
+			expect(executeCommandStub.withArgs("atlasmap.start").calledOnce, "AtlasMap start command was not issued").to.be.true;
+			expect(port, "Unable to determine used port for AtlasMap server").to.not.be.undefined;
+			expect(port, "Port for AtlasMap server seems to be NaN").to.not.be.NaN;
+			expect(createOutputChannelSpy.calledOnce);
 
-					let url:string = "http://localhost:" + port;
-					await testUtils.getWebUI(url)
-						.then( (body) => {
-							expect(body, "Unexpected html response body").to.contain("AtlasMap");
-							if (browserConfig === BrowserType.Internal) {
-								checkContainsAtlasMapTitle();
-							}
-							done();
-						})
-						.catch( (err) => {
-							console.error(err);
-							done(err);
-						});
-				})
-				.catch( err => {
-					console.error(err);
-					done(err);
-				});
+			const url :string = "http://localhost:" + port;
+			const body :string = await testUtils.getWebUI(url);
+			expect(body, "Unexpected html response body").to.contain("AtlasMap");
+			if (browserConfig === BrowserType.Internal) {
+				await checkContainsAtlasMapTitle();
+			}
 		});
 
 	});
 });
 
-function checkContainsAtlasMapTitle() {
+async function checkContainsAtlasMapTitle() {
 	const expectedAtlasMapTitle = '<title>AtlasMap Data Mapper UI</title>';
-	waitUntil(() => atlasMapWebView.default?.currentPanel?._panel.webview?.html?.includes(expectedAtlasMapTitle));
+	await waitUntil(() => atlasMapWebView.default?.currentPanel?._panel.webview?.html?.includes(expectedAtlasMapTitle));
 	expect(
 		atlasMapWebView.default?.currentPanel?._panel?.webview?.html,
-		`HTML doesn't contain url the ${expectedAtlasMapTitle}`).to.contain(expectedAtlasMapTitle);
+		`HTML doesn't contain ${expectedAtlasMapTitle}`).to.contain(expectedAtlasMapTitle);
 }


### PR DESCRIPTION
use await and async to have conditional wait respected …

the waitUntil wasn't respected before because it wasn't an async method
and no await was used. Consequently, the test was passing only when
there is no need of it. There was only a trace in log of a timeout
unresolved promise but it wasn't failing the test
