### PR TITLE
FUSETOOLS2-783 - upgrade vscode-extension-tester-locators to 1.50.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7792,9 +7792,9 @@
 			}
 		},
 		"vscode-extension-tester-locators": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.49.0.tgz",
-			"integrity": "sha512-I4k0Ph+r9v9x5ocre9mz2uwVNny+g464LP8wD13QxAHdeLjJHgniYKJibOQqhx+7d1y2/5nwlPKwGqH/4fGjuQ==",
+			"version": "1.50.0",
+			"resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.50.0.tgz",
+			"integrity": "sha512-dxxsQZk9s/zxKIj5aLKqVYqdPMAfQW9rSCGMVuLK6Ac0EDnx2uMe99DthzrfCOiov5BEXdA1MoqCcydrBxxNRg==",
 			"dev": true
 		},
 		"vscode-extension-tester-native": {


### PR DESCRIPTION
to fix master, to have it compatible with VS Code 1.50.0

Signed-off-by: Aurélien Pupier <apupier@redhat.com>