### PR TITLE
FUSETOOLS2-748 - use lts version of node on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "10.15.0"
+node_js: "lts/*"
 os: linux
 services:
   - xvfb


### PR DESCRIPTION
it will allow to stay aligned with jenkins

Signed-off-by: Aurélien Pupier <apupier@redhat.com>