### PR TITLE
FUSETOOLS2-784 - use .git suffix for git url

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 node('rhel8'){
 	stage('Checkout repo') {
 		deleteDir()
-		git url: 'https://github.com/jboss-fuse/vscode-atlasmap'
+		git url: 'https://github.com/jboss-fuse/vscode-atlasmap.git'
 	}
 
 	stage('Install requirements') {


### PR DESCRIPTION
it allows to have the poll in Pipeline Job to be working

Signed-off-by: Aurélien Pupier <apupier@redhat.com>