### PR TITLE
Update release information to use manual update of version package-lock.json

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -28,24 +28,26 @@ After calling the "Open AtlasMap" and that the AtlasMap panel is opened, some co
 ## How to provide a new version on VS Code Marketplace
 
 * Check that the version in package.json has not been published yet
-  * If already published:
-    * Upgrade the version in package.json
-    * Run 'npm install' so that the package-lock.json is updated
-    * Push changes in a PR
-    * Wait for PR to be merged
+    * If already published:
+        * Upgrade the version in package.json
+        * Run 'npm install' so that the package-lock.json is updated
+        * Push changes in a PR
+        * Wait for PR to be merged
 * Check that someone listed as _submitter_ in Jenkinsfile is available
 * Create a tag
 * Push the tag to vscode-atlasmap repository, it will trigger a build after few minutes
 * Check build is working fine on [Circle CI](https://app.circleci.com/pipelines/github/jboss-fuse/vscode-atlasmap)
-* Start build on [Jenkins CI](https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/VS%20Code/job/vscode-atlasmap-release) with _publishToMarketPlace_ parameter checked
+* Start build on [Jenkins CI](https://studio-jenkins-csb-codeready.apps.ocp4.prod.psi.redhat.com/job/Fuse/job/VSCode/job/vscode-atlasmap-release/) with _publishToMarketPlace_ and _publishToOVSX_ parameters checked
 * Wait the build is waiting on step _Publish to Marketplace_
-* Ensure you are logged in
-* Go to the console log of the build and click "Proceed"
-* Wait few minutes and check that it has been published on VS Code Marketplace
+* It is possible to check that the produced vsix is valid by using he one pushed in [Jboss download area](https://download.jboss.org/jbosstools/vscode/stable/vscode-atlasmap/)
+* For someone in _submitter_ list:
+  * Ensure you are logged in
+  * Go to the console log of the build and click "Proceed"
+* Wait few minutes and check that it has been published on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=redhat.atlasmap-viewer) and [Open VSX Marketplace](https://open-vsx.org/extension/redhat/atlasmap-viewer)
 * Keep build forever for later reference and edit build information to indicate the version
 * Prepare next iteration:
-  * Upgrade the version in package.json
-  * Run 'npm install' so that the package-lock.json is updated
-  * Push changes in a PR
-  * Follow PR until it is approved/merged
+    * Upgrade the version in package.json
+    * Run 'npm install' so that the package-lock.json is updated
+    * Push changes in a PR
+    * Follow PR until it is approved/merged
   

--- a/Contributing.md
+++ b/Contributing.md
@@ -30,7 +30,7 @@ After calling the "Open AtlasMap" and that the AtlasMap panel is opened, some co
 * Check that the version in package.json has not been published yet
     * If already published:
         * Upgrade the version in package.json
-        * Run 'npm install' so that the package-lock.json is updated
+        * Upgrade the version in package-lock.json
         * Push changes in a PR
         * Wait for PR to be merged
 * Check that someone listed as _submitter_ in Jenkinsfile is available
@@ -47,7 +47,7 @@ After calling the "Open AtlasMap" and that the AtlasMap panel is opened, some co
 * Keep build forever for later reference and edit build information to indicate the version
 * Prepare next iteration:
     * Upgrade the version in package.json
-    * Run 'npm install' so that the package-lock.json is updated
+    * Upgrade the version in package-lock.json
     * Push changes in a PR
     * Follow PR until it is approved/merged
   


### PR DESCRIPTION
based on https://github.com/jboss-fuse/vscode-atlasmap/pull/595

spun-off to tackle this specific point https://github.com/jboss-fuse/vscode-atlasmap/pull/595#discussion_r650993739

it indicates to update manually the process to avoid potentially thousands of modifications on each PR. That said, the diferent thousands of modifications were happenign opnly in Lars's environment. So we might continue to use npm install and just mention to ensure that the encironment is not modifying all contents of the file, just the package version.