### PR TITLE
FUSETOOLS2-1280 - Avoid reloading issue in Theia

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Upgrade to AtlasMap 2.2.3
 - Include opt-in telemetrics for usage information
+- Avoid reloading of AtlasMap UI on each focus gain/lost of the webview in Eclipse Theia
 
 ## 0.0.7
 

--- a/src/AtlasMapPanel.ts
+++ b/src/AtlasMapPanel.ts
@@ -14,6 +14,7 @@ export default class AtlasMapPanel {
 	public readonly _panel: vscode.WebviewPanel;
 	public readonly _context: vscode.ExtensionContext;
 	private _disposables: vscode.Disposable[] = [];
+	private previouslyVisible: boolean = true;
 
 	public static createOrShow(url: string, context: vscode.ExtensionContext) {
 		const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined;
@@ -61,9 +62,11 @@ export default class AtlasMapPanel {
 
 		// Update the content based on view changes
 		this._panel.onDidChangeViewState(e => {
-			if (this._panel.visible) {
+			// Checking for previous visibility because in Theia, the event is thrown also when taking focus which is causing too many reloads
+			if (this._panel.visible && !this.previouslyVisible) {
 				this._update(url);
 			}
+			this.previouslyVisible = this._panel.visible;
 		}, null, this._disposables);
 
 		// Handle messages from the webview


### PR DESCRIPTION
on first click after loading AtlasMap Ui in Theia, the UI is reloading.
It also reloads when the view is gaining or losing focus.

It is caused because Theia is triggering the event when gaining/losing
focus although VS Code sends it only when hiding/revealing.

A test would need to be added on Theia/Che side, do not see well how we
can test it efficiently on VS Code side.

Note: maybe we can completely remove the reload, or use a lighter
refresh mode. I think this would need to be investigated is a separated
PR as it can have a lot of impacts.

To test this PR:
* clone theia (currently with this [branch](https://github.com/apupier/theia/tree/5007-avoidRedirectLoop) until this [PR](https://github.com/eclipse-theia/theia/pull/10063) is merged)
* call `yarn`
* generate vsix from the branch of this PR and put it in <theia>/plugins folder
* go to <theia>/examples/browser
* call `yarn run start`
* go to localhost:3000
* Call command `Open AptlasMap`
* Click in the UI, there shouldn't be another reloading