### PR TITLE
FUSETOOLS2-1292 - migrate Docker image on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 job_default: &job_defaults
   working_directory: ~/vscode-atlasmap
   docker:
-    - image: circleci/node:lts-browsers
+    - image: cimg/node:lts-browsers
   
 jobs:
   build:

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.0.9
 
+- Allow automatic detection of JREs (and not only JDKs)
+
 ## 0.0.8
 
 - Upgrade to AtlasMap 2.2.3

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -61,7 +61,7 @@ function checkJavaRuntime(): Promise<string> {
 			return resolve(javaHome);
 		}
 		//No settings, let's try to detect as last resort.
-		findJavaHome(function (err, home) {
+		findJavaHome({allowJre: true},function (err, home) {
 			if (err) {
 				openJDKDownload(reject, 'Java runtime could not be located');
 			}


### PR DESCRIPTION
circleci/* are deprecated and to be replaced with cimg/*
