### PR TITLE
FUSETOOLS2-1388 - increase timeout to avoid failures on CircleCI

### DIFF
--- a/src/ui-test/editor.ts
+++ b/src/ui-test/editor.ts
@@ -77,7 +77,7 @@ export function editorTests() {
 		});
 		
 		it('Open several .adms in AtlasMap Editor', async function () {
-			this.timeout(30000);
+			this.timeout(60000);
 			const workspaceFolder = path.join(__dirname, '../../test Fixture with speci@l chars');
 			await VSBrowser.instance.openResources(workspaceFolder);
 			await openAdmFile(workspaceFolder, 'atlasmap-mapping.adm', driver);


### PR DESCRIPTION
this is a shame that it requires [35 seconds](https://app.circleci.com/pipelines/github/jboss-fuse/vscode-atlasmap/682/workflows/7e9eae24-05bb-460b-ac48-c72ba731c102/jobs/970?invite=true#step-109-46) to open 2 times AtlasMap on CI :-(
(means that for users with slow machine this is hardly sustainable)