### PR TITLE
FUSETOOLS2-1409 - Provide CI job for Windows and Mac

### DIFF
--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -1,0 +1,39 @@
+name: Test on secondary OSes
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+        cache: 'npm'
+    - name: Install typescript
+      run: npm install -g typescript
+    - name: Install vsce
+      run: npm install -g vsce
+    - name: Install dependencies
+      run: npm ci
+    - name: Package
+      run: vsce package
+    - name: Test
+      run: npm test
+    - name: UI Test
+      run: npm run ui-test     


### PR DESCRIPTION
Linux is currently handled by Circle CI

created on GitHub Actions because it is infinitely easier than on Circle CI with a mix of node and Java requirement