### PR TITLE
FUSETOOLS2-1490 - provide tags telemetry on telemetry setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
 					"type": "boolean",
 					"default": null,
 					"markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
-					"scope": "window"
+					"scope": "window",
+					"tags": ["telemetry"]
 				}
 			}
 		},


### PR DESCRIPTION
it allows to better reconcile the same setting shared between several
extensions

Signed-off-by: Aurélien Pupier <apupier@redhat.com>