### PR TITLE
FUSETOOLS2-1592 - use MacOS 12 on CI

### DIFF
--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-12]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
With MacOS 11, a lot of windows are opened when launching UI tests
causing very very unstable tests.
Given that it is a community project only, the latest Mac OS can be used
for testing.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>