### PR TITLE
Until Java 11.0.16 is release, deactivating windows tests

### DIFF
--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
see https://github.com/atlasmap/atlasmap/issues/3969 and
https://bugs.openjdk.java.net/browse/JDK-8285445

Signed-off-by: Aurélien Pupier <apupier@redhat.com>