### PR TITLE
FUSETOOLS2-1691 - fix create new file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"path": "^0.12.7",
 				"path-exists": "^4.0.0",
 				"util": "^0.12.4",
-				"valid-filename": "^4.0.0"
+				"valid-filename": "^3.1.0"
 			},
 			"devDependencies": {
 				"@types/chai": "^4.3.1",
@@ -8435,28 +8435,14 @@
 			}
 		},
 		"node_modules/valid-filename": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/valid-filename/-/valid-filename-4.0.0.tgz",
-			"integrity": "sha512-VEYTpTVPMgO799f2wI7zWf0x2C54bPX6NAfbZ2Z8kZn76p+3rEYCTYVYzMUcVSMvakxMQTriBf24s3+WeXJtEg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/valid-filename/-/valid-filename-3.1.0.tgz",
+			"integrity": "sha512-O99sdfhdGCiWoN4cv6Unq4eJ2EuXwRsOLCeSw+IJyMYgwVK0BPmaUnzhWQw5E8qknLTVrVExCr6xxTBnRBvtsQ==",
 			"dependencies": {
-				"filename-reserved-regex": "^3.0.0"
+				"filename-reserved-regex": "^2.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/valid-filename/node_modules/filename-reserved-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
-			"integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=6"
 			}
 		},
 		"node_modules/validate-npm-package-license": {
@@ -15947,18 +15933,11 @@
 			}
 		},
 		"valid-filename": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/valid-filename/-/valid-filename-4.0.0.tgz",
-			"integrity": "sha512-VEYTpTVPMgO799f2wI7zWf0x2C54bPX6NAfbZ2Z8kZn76p+3rEYCTYVYzMUcVSMvakxMQTriBf24s3+WeXJtEg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/valid-filename/-/valid-filename-3.1.0.tgz",
+			"integrity": "sha512-O99sdfhdGCiWoN4cv6Unq4eJ2EuXwRsOLCeSw+IJyMYgwVK0BPmaUnzhWQw5E8qknLTVrVExCr6xxTBnRBvtsQ==",
 			"requires": {
-				"filename-reserved-regex": "^3.0.0"
-			},
-			"dependencies": {
-				"filename-reserved-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
-					"integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="
-				}
+				"filename-reserved-regex": "^2.0.0"
 			}
 		},
 		"validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
 					"default": null,
 					"markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
 					"scope": "window",
-					"tags": ["telemetry"]
+					"tags": [
+						"telemetry"
+					]
 				}
 			}
 		},
@@ -114,7 +116,7 @@
 		"path": "^0.12.7",
 		"path-exists": "^4.0.0",
 		"util": "^0.12.4",
-		"valid-filename": "^4.0.0"
+		"valid-filename": "^3.1.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.3.1",

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -7,7 +7,7 @@ import * as sinonChai from "sinon-chai";
 import * as vscode from "vscode";
 import path = require('path');
 import { fail } from "assert";
-import { fileExists } from "../../extension";
+import { fileExists, validateFileName } from "../../extension";
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -60,5 +60,21 @@ describe('Test Command: atlasmap.file.create', function() {
 		} catch (err) {
 			fail(err);
 		}
+	});
+	
+	describe('Check validator for file name', () => {
+		
+		it('Check validator of input for valid file name', async function () {
+			expect(await validateFileName(wspFld, 'good name')).to.be.undefined;
+		});
+		
+		it('Check validator of input for invalid file name', async function () {
+			expect(await validateFileName(wspFld, 'wrong/name')).to.not.be.undefined;
+		});
+		
+		it('Check validator of input for invalid empty file name', async function () {
+			expect(await validateFileName(wspFld, '')).to.not.be.undefined;
+		});
+		
 	});
 });


### PR DESCRIPTION
switch back to valid-filename 3.1.0. Seems 4.0.0 requires "module" and
does not support the "CommonJS" which seems to be require din this
project so far. Created https://issues.redhat.com/browse/FUSETOOLS2-1693 to handle the upgrade later.

In case, we use the 4.0.0 with the provided syntax, ther eis this error:

Activating extension 'redhat.atlasmap-viewer' failed: require() of ES
Module /home/apupier/git/vscode-atlasmap/node_modules/valid-filename/index.js
from /home/apupier/git/vscode-atlasmap/out/extension.js not supported.
Instead change the require of index.js in
/home/apupier/git/vscode-atlasmap/out/extension.js to a dynamic import()
which is available in all CommonJS modules..


it would be nice to have a UI test, I started investigation but will need QE team to look at it to make it working and remove the driver.sleep  https://github.com/jboss-fuse/vscode-atlasmap/pull/846