### PR TITLE
FUSETOOLS2-1737 - Allow choice of placement of .adm file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.2.1
 
+- Added an option when using 'Create AtlasMap file' action to choose the placement of the .adm file inside the workspace.
+
 ## 0.2.0
 
 - Upgrade to AtlasMap 2.5.0. Beware 2.5.0 is based on 2.3.x which is older than 2.4.0-M4 this extension was previously based on. The main branch work is now suspended. Breaking changes: adm files created with 0.1.x VS Code AtlasMap might not be compatible with this new version. It should work in most of the cases but it is not guaranteed.

--- a/src/commands/file/create.ts
+++ b/src/commands/file/create.ts
@@ -1,0 +1,164 @@
+"use strict";
+
+import { TelemetryEvent } from '@redhat-developer/vscode-redhat-telemetry/lib';
+import path = require('path');
+import validFilename = require('valid-filename');
+import * as vscode from 'vscode';
+import { telemetryService } from '../../extension';
+
+export async function createAndOpenADM() {
+	const selectedWorkspaceFolder: vscode.WorkspaceFolder | undefined
+		= await promptUserForWorkspace();
+	
+	if (!selectedWorkspaceFolder) {
+		return;
+	}
+
+	let admFolderPath : string = selectedWorkspaceFolder.uri.fsPath;
+
+	const admFileAtWorkspaceRoot : boolean 
+		= await promptIfUserWantsAdmFileAtWorkspaceRoot();
+
+	if (admFileAtWorkspaceRoot === undefined) {
+		return;
+	}
+
+	if (!admFileAtWorkspaceRoot) {
+		const admFolderUri : vscode.Uri | undefined 
+			= await promptUserForAdmFileLocationInWorkspace(selectedWorkspaceFolder);
+
+		if (!admFolderUri) {
+			return;
+		}
+
+		admFolderPath = admFolderUri.fsPath;
+	}
+
+	const fileName: string | undefined 
+		= await promptForAdmFileName(selectedWorkspaceFolder);
+
+	if (fileName) {
+		await createAdmFile(admFolderPath, fileName);
+	}
+}
+
+async function promptUserForWorkspace() : Promise<vscode.WorkspaceFolder | undefined> {
+	return vscode.window.showWorkspaceFolderPick(
+		{placeHolder: 'Please select the workspace folder in which the new file will be created.'});
+}
+
+async function promptIfUserWantsAdmFileAtWorkspaceRoot() : Promise<boolean | undefined> {
+	const userSelection = await vscode.window.showQuickPick(
+		["Workspace root", "Select a folder inside Workspace"], {placeHolder: "Select the location of the .adm file"}
+	);
+
+	if (!userSelection) {
+		return undefined;
+	}
+
+	return userSelection === "Workspace root";
+}
+
+async function promptUserForAdmFileLocationInWorkspace(workspaceRoot: vscode.WorkspaceFolder) 
+	: Promise<vscode.Uri | undefined> {
+
+	let admFolderUri = await promptUserForDirectoryForAdmFile(workspaceRoot);
+
+	if (!admFolderUri) {
+		return undefined;
+	}
+
+	while(!folderIsInside(workspaceRoot.uri.fsPath, admFolderUri.fsPath)) {
+		showFolderOutsideWorkspaceErrorMessage();
+
+		admFolderUri = await promptUserForDirectoryForAdmFile(workspaceRoot);
+
+		if (!admFolderUri) {
+			return undefined;
+		}
+	}
+
+	return admFolderUri;
+}
+
+async function promptForAdmFileName(workspaceFolder : vscode.WorkspaceFolder)
+	: Promise<string | undefined> {
+	return vscode.window.showInputBox(
+		{placeHolder: "Enter the name of the new AtlasMap file",
+		validateInput: async (name: string) => {
+			return validateFileName(workspaceFolder, name);
+	}});
+}
+
+async function createAdmFile(admFolderPath : string, fileName : string) {
+	const file = `${admFolderPath}/${getValidFileNameWithExtension(fileName)}`;
+	await vscode.workspace.fs.writeFile(vscode.Uri.file(file), Buffer.from(''));
+	await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(file));
+	sendCreateEvent();
+}
+
+function showFolderOutsideWorkspaceErrorMessage() {
+	vscode.window.showErrorMessage(
+		"The chosen folder was outside of the workspace. You need to select a folder inside the workspace to create the AtlasMap Data transformation file.");
+}
+
+async function promptUserForDirectoryForAdmFile(workspaceRoot: vscode.WorkspaceFolder)
+	: Promise<vscode.Uri | undefined> {
+
+	const options: vscode.OpenDialogOptions = {
+		defaultUri: workspaceRoot.uri,
+		canSelectMany: false,
+		openLabel: 'Select',
+		canSelectFiles: false,
+		canSelectFolders: true,
+		title: "Select the location of the .adm file in the Workspace."
+	};
+
+	let admFolderUriArray = await vscode.window.showOpenDialog(options);
+	
+	if (!admFolderUriArray) {
+		return undefined;
+	}
+
+	return admFolderUriArray[0];
+}
+
+function folderIsInside(parentFolder: string, subFolder: string) : boolean {
+	const rel = path.relative(parentFolder, subFolder);
+	return !rel.startsWith('../') && rel !== '..';
+}
+
+export async function validateFileName(selectedWorkspaceFolder: vscode.WorkspaceFolder, fileName): Promise<string> {
+	const file: string = `${selectedWorkspaceFolder.uri.fsPath}/${getValidFileNameWithExtension(fileName)}`;
+		if (!validFilename(fileName)) {
+			return 'The filename is invalid.';
+		}
+		if (await fileExists(vscode.Uri.file(file))) {
+			return `A file with that name already exists.`;
+		}
+		return undefined;
+}
+
+function getValidFileNameWithExtension(name: string): string {
+	if (name && !name.toLowerCase().endsWith('.adm')) {
+		return `${name}.adm`;
+	}
+	return name;
+}
+
+export async function fileExists(file: vscode.Uri): Promise<boolean> {
+	try {
+		await vscode.workspace.fs.stat(file);
+	} catch {
+		return false;
+	}
+	return true;
+}
+
+function sendCreateEvent() {
+	const telemetryEvent: TelemetryEvent = {
+		type: 'track',
+		name: 'atlasmap.file.create'
+	};
+	telemetryService.send(telemetryEvent);
+}

--- a/src/commands/file/create.ts
+++ b/src/commands/file/create.ts
@@ -10,35 +10,31 @@ export async function createAndOpenADM() {
 	const selectedWorkspaceFolder: vscode.WorkspaceFolder | undefined
 		= await promptUserForWorkspace();
 	
-	if (!selectedWorkspaceFolder) {
-		return;
-	}
+	if (selectedWorkspaceFolder) {
+		let admFolderPath : string = selectedWorkspaceFolder.uri.fsPath;
 
-	let admFolderPath : string = selectedWorkspaceFolder.uri.fsPath;
+		const admFileAtDifferentPlaceThanRoot : boolean 
+			= await promptIfUserWantsAdmFileAtWorkspaceRoot();
 
-	const admFileAtWorkspaceRoot : boolean 
-		= await promptIfUserWantsAdmFileAtWorkspaceRoot();
-
-	if (admFileAtWorkspaceRoot === undefined) {
-		return;
-	}
-
-	if (!admFileAtWorkspaceRoot) {
-		const admFolderUri : vscode.Uri | undefined 
-			= await promptUserForAdmFileLocationInWorkspace(selectedWorkspaceFolder);
-
-		if (!admFolderUri) {
+		if (admFileAtDifferentPlaceThanRoot === undefined) {
 			return;
+		} else if (admFileAtDifferentPlaceThanRoot) {
+			const admFolderUri : vscode.Uri | undefined 
+				= await promptUserForAdmFileLocationInWorkspace(selectedWorkspaceFolder);
+
+			if (!admFolderUri) {
+				return;
+			}
+
+			admFolderPath = admFolderUri.fsPath;
 		}
 
-		admFolderPath = admFolderUri.fsPath;
-	}
+		const fileName: string | undefined 
+			= await promptForAdmFileName(selectedWorkspaceFolder);
 
-	const fileName: string | undefined 
-		= await promptForAdmFileName(selectedWorkspaceFolder);
-
-	if (fileName) {
-		await createAdmFile(admFolderPath, fileName);
+		if (fileName) {
+			await createAdmFile(admFolderPath, fileName);
+		}
 	}
 }
 
@@ -56,7 +52,7 @@ async function promptIfUserWantsAdmFileAtWorkspaceRoot() : Promise<boolean | und
 		return undefined;
 	}
 
-	return userSelection === "Workspace root";
+	return userSelection === "Select a folder inside Workspace";
 }
 
 async function promptUserForAdmFileLocationInWorkspace(workspaceRoot: vscode.WorkspaceFolder) 

--- a/src/commands/file/create.ts
+++ b/src/commands/file/create.ts
@@ -14,7 +14,7 @@ export async function createAndOpenADM() {
 		let admFolderPath : string = selectedWorkspaceFolder.uri.fsPath;
 
 		const admFileAtDifferentPlaceThanRoot : boolean 
-			= await promptIfUserWantsAdmFileAtWorkspaceRoot();
+			= await promptUserIfHeWantsAdmFileAtCustomLocationInWorkspace();
 
 		if (admFileAtDifferentPlaceThanRoot === undefined) {
 			return;
@@ -43,7 +43,7 @@ async function promptUserForWorkspace() : Promise<vscode.WorkspaceFolder | undef
 		{placeHolder: 'Please select the workspace folder in which the new file will be created.'});
 }
 
-async function promptIfUserWantsAdmFileAtWorkspaceRoot() : Promise<boolean | undefined> {
+async function promptUserIfHeWantsAdmFileAtCustomLocationInWorkspace() : Promise<boolean | undefined> {
 	const userSelection = await vscode.window.showQuickPick(
 		["Workspace root", "Select a folder inside Workspace"], {placeHolder: "Select the location of the .adm file"}
 	);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { getRedHatService, TelemetryEvent, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry";
 import { AtlasMapEditorProvider } from './editor/AtlasMapEditorProvider';
 import { AtlasMapDocument } from './editor/AtlasMapDocument';
+import { createAndOpenADM } from './commands/file/create';
 
 const validFilename = require('valid-filename');
 const chokidar = require('chokidar');
@@ -53,171 +54,10 @@ function sendOpenEvent() {
 	telemetryService.send(telemetryEvent);
 }
 
-function sendCreateEvent() {
-	const telemetryEvent: TelemetryEvent = {
-		type: 'track',
-		name: 'atlasmap.file.create'
-	};
-	telemetryService.send(telemetryEvent);
-}
-
 export function deactivate(context: vscode.ExtensionContext) {
 	if (telemetryService) {
 		telemetryService.sendShutdownEvent();
 	}
-}
-
-async function createAndOpenADM() {
-	const selectedWorkspaceFolder: vscode.WorkspaceFolder | undefined
-		= await promptUserForWorkspace();
-	
-	if (!selectedWorkspaceFolder) {
-		return;
-	}
-
-	let admFolderPath : string = selectedWorkspaceFolder.uri.fsPath;
-
-	const admFileAtWorkspaceRoot : boolean 
-		= await promptIfUserWantsAdmFileAtWorkspaceRoot();
-
-	if (admFileAtWorkspaceRoot === undefined) {
-		return;
-	}
-
-	if (!admFileAtWorkspaceRoot) {
-		const admFolderUri : vscode.Uri | undefined 
-			= await promptUserForAdmFileLocationInWorkspace(selectedWorkspaceFolder);
-
-		if (!admFolderUri) {
-			return;
-		}
-
-		admFolderPath = admFolderUri.fsPath;
-	}
-
-	const fileName: string | undefined 
-		= await promptForAdmFileName(selectedWorkspaceFolder);
-
-	if (fileName) {
-		await createAdmFile(admFolderPath, fileName);
-	}
-}
-
-async function promptUserForWorkspace() : Promise<vscode.WorkspaceFolder | undefined> {
-	return vscode.window.showWorkspaceFolderPick(
-		{placeHolder: 'Please select the workspace folder in which the new file will be created.'});
-}
-
-async function promptIfUserWantsAdmFileAtWorkspaceRoot() : Promise<boolean | undefined> {
-	const userSelection = await vscode.window.showQuickPick(
-		["Workspace root", "Select a folder inside Workspace"], {placeHolder: "Select the location of the .adm file"}
-	);
-
-	if (!userSelection) {
-		return undefined;
-	}
-
-	return userSelection === "Workspace root";
-}
-
-async function promptUserForAdmFileLocationInWorkspace(workspaceRoot: vscode.WorkspaceFolder) 
-	: Promise<vscode.Uri | undefined> {
-
-	let admFolderUri = await promptUserForDirectoryForAdmFile(workspaceRoot);
-
-	if (!admFolderUri) {
-		return undefined;
-	}
-
-	while(!folderIsInside(workspaceRoot.uri.fsPath, admFolderUri.fsPath)) {
-		showFolderOutsideWorkspaceErrorMessage();
-
-		admFolderUri = await promptUserForDirectoryForAdmFile(workspaceRoot);
-
-		if (!admFolderUri) {
-			return undefined;
-		}
-	}
-
-	return admFolderUri;
-}
-
-async function promptForAdmFileName(workspaceFolder : vscode.WorkspaceFolder)
-	: Promise<string | undefined> {
-	return vscode.window.showInputBox(
-		{placeHolder: "Enter the name of the new AtlasMap file",
-		validateInput: async (name: string) => {
-			return validateFileName(workspaceFolder, name);
-	}});
-}
-
-async function createAdmFile(admFolderPath : string, fileName : string) {
-	const file = `${admFolderPath}/${getValidFileNameWithExtension(fileName)}`;
-	await vscode.workspace.fs.writeFile(vscode.Uri.file(file), Buffer.from(''));
-	await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(file));
-	sendCreateEvent();
-}
-
-function showFolderOutsideWorkspaceErrorMessage() {
-	vscode.window.showErrorMessage(
-		"The chosen folder was outside of the workspace. You need to select a folder inside the workspace to create the AtlasMap Data transformation file.");
-}
-
-function showUserAbortingInfoMessage() {
-	vscode.window.showInformationMessage("Cancelled by the user");
-}
-
-async function promptUserForDirectoryForAdmFile(workspaceRoot: vscode.WorkspaceFolder)
-	: Promise<vscode.Uri | undefined> {
-
-	const options: vscode.OpenDialogOptions = {
-		defaultUri: workspaceRoot.uri,
-		canSelectMany: false,
-		openLabel: 'Select',
-		canSelectFiles: false,
-		canSelectFolders: true,
-		title: "Select the location of the .adm file in the Workspace."
-	};
-
-	let admFolderUriArray = await vscode.window.showOpenDialog(options);
-	
-	if (!admFolderUriArray) {
-		return undefined;
-	}
-
-	return admFolderUriArray[0];
-}
-
-function folderIsInside(parentFolder: string, subFolder: string) : boolean {
-	const rel = path.relative(parentFolder, subFolder);
-	return !rel.startsWith('../') && rel !== '..';
-}
-
-export async function validateFileName(selectedWorkspaceFolder: vscode.WorkspaceFolder, fileName): Promise<string> {
-	const file: string = `${selectedWorkspaceFolder.uri.fsPath}/${getValidFileNameWithExtension(fileName)}`;
-		if (!validFilename(fileName)) {
-			return 'The filename is invalid.';
-		}
-		if (await fileExists(vscode.Uri.file(file))) {
-			return `A file with that name already exists.`;
-		}
-		return undefined;
-}
-
-function getValidFileNameWithExtension(name: string): string {
-	if (name && !name.toLowerCase().endsWith('.adm')) {
-		return `${name}.adm`;
-	}
-	return name;
-}
-
-export async function fileExists(file: vscode.Uri): Promise<boolean> {
-	try {
-		await vscode.workspace.fs.stat(file);
-	} catch {
-		return false;
-	}
-	return true;
 }
 
 export function launchAtlasMapLocally(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,6 @@ async function createAndOpenADM() {
 		= await promptUserForWorkspace();
 	
 	if (!selectedWorkspaceFolder) {
-		showUserAbortingInfoMessage();
 		return;
 	}
 
@@ -81,12 +80,15 @@ async function createAndOpenADM() {
 	const admFileAtWorkspaceRoot : boolean 
 		= await promptIfUserWantsAdmFileAtWorkspaceRoot();
 
+	if (admFileAtWorkspaceRoot === undefined) {
+		return;
+	}
+
 	if (!admFileAtWorkspaceRoot) {
 		const admFolderUri : vscode.Uri | undefined 
 			= await promptUserForAdmFileLocationInWorkspace(selectedWorkspaceFolder);
 
 		if (!admFolderUri) {
-			showUserAbortingInfoMessage();
 			return;
 		}
 
@@ -98,8 +100,6 @@ async function createAndOpenADM() {
 
 	if (fileName) {
 		await createAdmFile(admFolderPath, fileName);
-	} else {
-		showUserAbortingInfoMessage();
 	}
 }
 
@@ -108,12 +108,16 @@ async function promptUserForWorkspace() : Promise<vscode.WorkspaceFolder | undef
 		{placeHolder: 'Please select the workspace folder in which the new file will be created.'});
 }
 
-async function promptIfUserWantsAdmFileAtWorkspaceRoot() : Promise<boolean> {
+async function promptIfUserWantsAdmFileAtWorkspaceRoot() : Promise<boolean | undefined> {
 	const userSelection = await vscode.window.showQuickPick(
 		["Workspace root", "Select a folder inside Workspace"], {placeHolder: "Select the location of the .adm file"}
 	);
 
-	return !userSelection || userSelection === "Workspace root";
+	if (!userSelection) {
+		return undefined;
+	}
+
+	return userSelection === "Workspace root";
 }
 
 async function promptUserForAdmFileLocationInWorkspace(workspaceRoot: vscode.WorkspaceFolder) 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,12 @@ async function createAndOpenADM() {
 				title: "Select the location of the .adm file in the Workspace."
 			};
 		
-			let admFolderUri = (await vscode.window.showOpenDialog(options))[0];
+			let admFolderUriArray = await vscode.window.showOpenDialog(options);
+			if (!admFolderUriArray) {
+				vscode.window.showInformationMessage("Cancelled by the user");
+				return;
+			}
+			let admFolderUri = admFolderUriArray[0];
 			while(!folderIsInside(selectedWorkspaceFolder.uri.fsPath, admFolderUri.fsPath)) {
 				vscode.window.showErrorMessage(
 					"The chosen folder was outside of the workspace. You need to select a folder inside the workspace to create the AtlasMap Data transformation file.");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ async function createAndOpenADM() {
 			["Workspace root", "Select a folder inside Workspace"], {placeHolder: "Select the location of the .adm file"}
 		);
 		let admFolder = selectedWorkspaceFolder.uri.fsPath;
-		if(admFileLocationChoice === "Select a folder inside workspace") {
+		if(admFileLocationChoice === "Select a folder inside Workspace") {
 			const options: vscode.OpenDialogOptions = {
 				defaultUri: selectedWorkspaceFolder.uri,
 				canSelectMany: false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,34 +69,43 @@ export function deactivate(context: vscode.ExtensionContext) {
 
 async function createAndOpenADM() {
 	const selectedWorkspaceFolder: vscode.WorkspaceFolder | undefined
-		= await vscode.window.showWorkspaceFolderPick(
-			{placeHolder: 'Please select the workspace folder in which the new file will be created.'});
+		= await promptUserForWorkspace();
 	
-	if (selectedWorkspaceFolder) {
-		let admFolderPath : string = selectedWorkspaceFolder.uri.fsPath;
-	
-		const admFileAtWorkspaceRoot : boolean 
-			= await promptIfUserWantsAdmFileAtWorkspaceRoot();
-
-		if (!admFileAtWorkspaceRoot) {
-			const admFolderUri : vscode.Uri | undefined 
-				= await promptUserForAdmFileLocationInWorkspace(selectedWorkspaceFolder);
-
-			if (!admFolderUri) {
-				showUserAbortingInfoMessage();
-				return;
-			}
-
-			admFolderPath = admFolderUri.fsPath;
-		}
-
-		const fileName: string | undefined 
-			= await promptForAdmFileName(selectedWorkspaceFolder);
-
-		if (fileName) {
-			await createAdmFile(admFolderPath, fileName);
-		}
+	if (!selectedWorkspaceFolder) {
+		showUserAbortingInfoMessage();
+		return;
 	}
+
+	let admFolderPath : string = selectedWorkspaceFolder.uri.fsPath;
+
+	const admFileAtWorkspaceRoot : boolean 
+		= await promptIfUserWantsAdmFileAtWorkspaceRoot();
+
+	if (!admFileAtWorkspaceRoot) {
+		const admFolderUri : vscode.Uri | undefined 
+			= await promptUserForAdmFileLocationInWorkspace(selectedWorkspaceFolder);
+
+		if (!admFolderUri) {
+			showUserAbortingInfoMessage();
+			return;
+		}
+
+		admFolderPath = admFolderUri.fsPath;
+	}
+
+	const fileName: string | undefined 
+		= await promptForAdmFileName(selectedWorkspaceFolder);
+
+	if (fileName) {
+		await createAdmFile(admFolderPath, fileName);
+	} else {
+		showUserAbortingInfoMessage();
+	}
+}
+
+async function promptUserForWorkspace() : Promise<vscode.WorkspaceFolder | undefined> {
+	return vscode.window.showWorkspaceFolderPick(
+		{placeHolder: 'Please select the workspace folder in which the new file will be created.'});
 }
 
 async function promptIfUserWantsAdmFileAtWorkspaceRoot() : Promise<boolean> {

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -15,6 +15,21 @@ chai.use(sinonChai);
 
 describe('Test Command: atlasmap.file.create', function() {
 
+	const WORKSPACE_SELECTOR_ASSERTION_LABEL = 
+		"Workspace selection input was shown";
+	const ADM_LOCATION_SELECTOR_ASSERTION_LABEL =
+		".adm location quick pick was shown";
+	const FILE_NAME_INPUT_ASSERTION_LABEL =
+		"File name input was shown";
+	const SELECT_FOLDER_WINDOW_ASSERTION_LABEL =
+		"Folder selection window was shown";
+	const INFO_MESSAGE_ASSERTION_LABEL =
+		"Information message was shown telling the user about the command cancelling";
+	const ERROR_MESSAGE_ASSERTION_LABEL =
+		"Error message telling user that the .adm file must be inside workspace was shown";
+	const FILE_CREATED_ASSERTION_LABEL =
+		location => `The .adm file was created at expected location: ${location}`;
+
 	let sandbox: sinon.SinonSandbox;
 	let workspaceSelectorStub: sinon.SinonStub;
 	let admLocationStub: sinon.SinonStub;
@@ -75,10 +90,10 @@ describe('Test Command: atlasmap.file.create', function() {
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
 			testADMFile = vscode.Uri.file(`${workspaceFolderUri.path}/${testADMFileName}`);
-			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
-			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
-			expect(fileNameInputStub.called, 'File name has not been asked').to.be.true;
-			expect(await fileExists(testADMFile), 'The created file does not exist').to.be.true;
+			expect(workspaceSelectorStub.called, WORKSPACE_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(admLocationStub.called, ADM_LOCATION_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(fileNameInputStub.called, FILE_NAME_INPUT_ASSERTION_LABEL).to.be.true;
+			expect(await fileExists(testADMFile), FILE_CREATED_ASSERTION_LABEL(testADMFile)).to.be.true;
 		} catch (err) {
 			fail(err);
 		}
@@ -98,12 +113,12 @@ describe('Test Command: atlasmap.file.create', function() {
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
 			testADMFile = vscode.Uri.file(`${tempFolderUri}/${testADMFileName}`);
-			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
-			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
-			expect(dirPickerWindow.called, 'Window directory picker was not called').to.be.true;
-			expect(fileNameInputStub.called, 'File name has not been asked').to.be.true;
+			expect(workspaceSelectorStub.called, WORKSPACE_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(admLocationStub.called, ADM_LOCATION_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(dirPickerWindow.called, SELECT_FOLDER_WINDOW_ASSERTION_LABEL).to.be.true;
+			expect(fileNameInputStub.called, FILE_NAME_INPUT_ASSERTION_LABEL).to.be.true;
 			expect(await fileExists(testADMFile),
-				'The created file does not exist').to.be.true;
+				FILE_CREATED_ASSERTION_LABEL(testADMFile)).to.be.true;
 		} catch (err) {
 			fail(err);
 		} finally {
@@ -117,8 +132,8 @@ describe('Test Command: atlasmap.file.create', function() {
 
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
-			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
-			expect(infoMessageStub.called, 'Info message was not shown').to.be.true;
+			expect(workspaceSelectorStub.called, WORKSPACE_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(infoMessageStub.called, INFO_MESSAGE_ASSERTION_LABEL).to.be.true;
 		} catch (err) {
 			fail(err);
 		}
@@ -132,10 +147,10 @@ describe('Test Command: atlasmap.file.create', function() {
 
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
-			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
-			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
-			expect(dirPickerWindow.called, 'Window directory picker was not called').to.be.true;
-			expect(infoMessageStub.called, 'Info message was not shown').to.be.true;
+			expect(workspaceSelectorStub.called, WORKSPACE_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(admLocationStub.called, ADM_LOCATION_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(dirPickerWindow.called, SELECT_FOLDER_WINDOW_ASSERTION_LABEL).to.be.true;
+			expect(infoMessageStub.called, INFO_MESSAGE_ASSERTION_LABEL).to.be.true;
 		} catch (err) {
 			fail(err);
 		}
@@ -154,11 +169,11 @@ describe('Test Command: atlasmap.file.create', function() {
 
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
-			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
-			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
+			expect(workspaceSelectorStub.called, WORKSPACE_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(admLocationStub.called, ADM_LOCATION_SELECTOR_ASSERTION_LABEL).to.be.true;
 			expect(dirPickerWindow.calledTwice,
 				`Window directory picker was not called or wasn't shown again`).to.be.true;
-			expect(errorMessageStub.called, 'Error message was not shown').to.be.true;
+			expect(errorMessageStub.called, ERROR_MESSAGE_ASSERTION_LABEL).to.be.true;
 		} catch (err) {
 			fail(err);
 		}
@@ -173,10 +188,10 @@ describe('Test Command: atlasmap.file.create', function() {
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
 			testADMFile = vscode.Uri.file(`${workspaceFolderUri.path}/${testADMFileName}`);
-			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
-			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
-			expect(fileNameInputStub.called, 'File name has not been asked').to.be.true;
-			expect(infoMessageStub.called, 'Info message was not shown').to.be.true;
+			expect(workspaceSelectorStub.called, WORKSPACE_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(admLocationStub.called, ADM_LOCATION_SELECTOR_ASSERTION_LABEL).to.be.true;
+			expect(fileNameInputStub.called, FILE_NAME_INPUT_ASSERTION_LABEL).to.be.true;
+			expect(infoMessageStub.called, INFO_MESSAGE_ASSERTION_LABEL).to.be.true;
 		} catch (err) {
 			fail(err);
 		}

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -16,21 +16,24 @@ describe('Test Command: atlasmap.file.create', function() {
 
 	let sandbox: sinon.SinonSandbox;
 	let workspaceSelectorStub: sinon.SinonStub;
+	let admLocationStub: sinon.SinonStub;
 	let fileNameInputStub: sinon.SinonStub;
 	
 	const testADMFileName: string = 'test.adm';
 	let testADMFile: vscode.Uri;
-	let workspaceFolder: vscode.Uri;
-	let wspFld: vscode.WorkspaceFolder;
+	let workspaceFolderUri: vscode.Uri;
+	let workspaceFolder: vscode.WorkspaceFolder;
 
 	before( async () => {
 		sandbox = sinon.createSandbox();
 
-		workspaceFolder = vscode.Uri.file(path.join(__dirname, '../../../test Fixture with speci@l chars'));
-		wspFld = vscode.workspace.getWorkspaceFolder(workspaceFolder);
+		workspaceFolderUri = vscode.Uri.file(path.join(__dirname, '../../../test Fixture with speci@l chars'));
+		workspaceFolder = vscode.workspace.getWorkspaceFolder(workspaceFolderUri);
 		
 		workspaceSelectorStub = sinon.stub(vscode.window, 'showWorkspaceFolderPick');
-		workspaceSelectorStub.returns(wspFld);
+		workspaceSelectorStub.returns(workspaceFolder);
+		admLocationStub = sinon.stub(vscode.window, 'showQuickPick');
+		admLocationStub.returns("");
 		fileNameInputStub = sinon.stub(vscode.window, 'showInputBox');
 	});
 
@@ -53,8 +56,9 @@ describe('Test Command: atlasmap.file.create', function() {
 		fileNameInputStub.onFirstCall().returns(testADMFileName);
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
-			testADMFile = vscode.Uri.file(`${workspaceFolder.path}/${testADMFileName}`);
+			testADMFile = vscode.Uri.file(`${workspaceFolderUri.path}/${testADMFileName}`);
 			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
+			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
 			expect(fileNameInputStub.called, 'File name has not been asked').to.be.true;
 			expect(await fileExists(testADMFile), 'The created file does not exist').to.be.true;
 		} catch (err) {
@@ -65,15 +69,15 @@ describe('Test Command: atlasmap.file.create', function() {
 	describe('Check validator for file name', () => {
 		
 		it('Check validator of input for valid file name', async function () {
-			expect(await validateFileName(wspFld, 'good name')).to.be.undefined;
+			expect(await validateFileName(workspaceFolder, 'good name')).to.be.undefined;
 		});
 		
 		it('Check validator of input for invalid file name', async function () {
-			expect(await validateFileName(wspFld, 'wrong/name')).to.not.be.undefined;
+			expect(await validateFileName(workspaceFolder, 'wrong/name')).to.not.be.undefined;
 		});
 		
 		it('Check validator of input for invalid empty file name', async function () {
-			expect(await validateFileName(wspFld, '')).to.not.be.undefined;
+			expect(await validateFileName(workspaceFolder, '')).to.not.be.undefined;
 		});
 		
 	});

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -13,7 +13,7 @@ import * as fs from "fs";
 const expect = chai.expect;
 chai.use(sinonChai);
 
-describe.only('Test Command: atlasmap.file.create', function() {
+describe('Test Command: atlasmap.file.create', function() {
 
 	let sandbox: sinon.SinonSandbox;
 	let workspaceSelectorStub: sinon.SinonStub;

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -19,8 +19,9 @@ describe.only('Test Command: atlasmap.file.create', function() {
 	let workspaceSelectorStub: sinon.SinonStub;
 	let admLocationStub: sinon.SinonStub;
 	let fileNameInputStub: sinon.SinonStub;
-	
-	const testADMFileName: string = 'test.adm';
+	let dirPickerWindow: sinon.SinonStub;
+
+	let testADMFileName: string = 'test.adm';
 	let testADMFile: vscode.Uri;
 	let workspaceFolderUri: vscode.Uri;
 	let workspaceFolder: vscode.WorkspaceFolder;
@@ -30,18 +31,20 @@ describe.only('Test Command: atlasmap.file.create', function() {
 
 		workspaceFolderUri = vscode.Uri.file(path.join(__dirname, '../../../test Fixture with speci@l chars'));
 		workspaceFolder = vscode.workspace.getWorkspaceFolder(workspaceFolderUri);
-		
+
 		workspaceSelectorStub = sinon.stub(vscode.window, 'showWorkspaceFolderPick');
-		workspaceSelectorStub.returns(workspaceFolder);
 		admLocationStub = sinon.stub(vscode.window, 'showQuickPick');
-		admLocationStub.returns("");
 		fileNameInputStub = sinon.stub(vscode.window, 'showInputBox');
+		dirPickerWindow = sinon.stub(vscode.window, 'showOpenDialog');
+
 	});
 
 	after( async () => {
 		sandbox.restore();
 		workspaceSelectorStub.restore();
 		fileNameInputStub.restore();
+		admLocationStub.restore();
+		dirPickerWindow.restore();
 
 		if (testADMFile && await fileExists(testADMFile)) {
 			await vscode.workspace.fs.delete(testADMFile);
@@ -51,10 +54,15 @@ describe.only('Test Command: atlasmap.file.create', function() {
 	afterEach( async () => {
 		workspaceSelectorStub.resetHistory();
 		fileNameInputStub.resetHistory();
+		admLocationStub.resetHistory();
 	});
 
 	it('Test execution of command and creation of file', async function() {
+				
+		workspaceSelectorStub.returns(workspaceFolder);
+		admLocationStub.returns("");
 		fileNameInputStub.onFirstCall().returns(testADMFileName);
+
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
 			testADMFile = vscode.Uri.file(`${workspaceFolderUri.path}/${testADMFileName}`);
@@ -67,34 +75,30 @@ describe.only('Test Command: atlasmap.file.create', function() {
 		}
 	});
 	
-	it.only('Test execution of command and creation of file', async function() {
+	it('Test execution of command and creation of file on different directory', async function() {
 
 		const tempFolder = "admTmp";
 		const tempFolderUri = path.join(workspaceFolder.uri.path, tempFolder);
 		fs.mkdirSync(tempFolderUri);
 
-		workspaceSelectorStub = sinon.stub(vscode.window, 'showWorkspaceFolderPick');
 		workspaceSelectorStub.returns(workspaceFolder);
-		admLocationStub = sinon.stub(vscode.window, 'showQuickPick');
 		admLocationStub.returns("Select a folder inside workspace");
-		const dirPickerWindow = sinon.stub(vscode.window, 'showOpenDialog');
-		dirPickerWindow.resolves([vscode.Uri.file(".")] as vscode.Uri[]);
-		fileNameInputStub = sinon.stub(vscode.window, 'showInputBox');
+		dirPickerWindow.resolves([vscode.Uri.file(tempFolderUri)] as vscode.Uri[]);
 		fileNameInputStub.onFirstCall().returns(testADMFileName);
 
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
-			testADMFile = vscode.Uri.file(`${workspaceFolderUri.path}/${testADMFileName}`);
+			testADMFile = vscode.Uri.file(`${tempFolderUri}/${testADMFileName}`);
 			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
 			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
 			expect(dirPickerWindow.called, 'Window directory picker was not called').to.be.true;
 			expect(fileNameInputStub.called, 'File name has not been asked').to.be.true;
-			expect(await fileExists(vscode.Uri.file(path.join(tempFolderUri, testADMFileName))),
-			 'The created file does not exist').to.be.true;
+			expect(await fileExists(testADMFile),
+				'The created file does not exist').to.be.true;
 		} catch (err) {
 			fail(err);
 		} finally {
-			fs.rmdirSync(tempFolderUri, {force: true, recursive: true})
+			fs.rmSync(tempFolderUri, {force:true, recursive: true});
 		}
 	});
 

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -111,6 +111,19 @@ describe('Test Command: atlasmap.file.create', function() {
 		}
 	});
 
+	it('Test user cancelling picking up workspace', async function() {
+
+		workspaceSelectorStub.returns("");
+
+		try {
+			await vscode.commands.executeCommand('atlasmap.file.create');
+			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
+			expect(infoMessageStub.called, 'Info message was not shown').to.be.true;
+		} catch (err) {
+			fail(err);
+		}
+	});
+
 	it('Test user cancelling picking up directory', async function() {
 
 		workspaceSelectorStub.returns(workspaceFolder);
@@ -146,6 +159,24 @@ describe('Test Command: atlasmap.file.create', function() {
 			expect(dirPickerWindow.calledTwice,
 				`Window directory picker was not called or wasn't shown again`).to.be.true;
 			expect(errorMessageStub.called, 'Error message was not shown').to.be.true;
+		} catch (err) {
+			fail(err);
+		}
+	});
+
+	it('Test user cancelling picking up a file name', async function() {
+
+		workspaceSelectorStub.returns(workspaceFolder);
+		admLocationStub.returns("");
+		fileNameInputStub.returns("");
+
+		try {
+			await vscode.commands.executeCommand('atlasmap.file.create');
+			testADMFile = vscode.Uri.file(`${workspaceFolderUri.path}/${testADMFileName}`);
+			expect(workspaceSelectorStub.called, 'Workspace Selector has not been called').to.be.true;
+			expect(admLocationStub.called, 'Adm location selection has not been called').to.be.true;
+			expect(fileNameInputStub.called, 'File name has not been asked').to.be.true;
+			expect(infoMessageStub.called, 'Info message was not shown').to.be.true;
 		} catch (err) {
 			fail(err);
 		}

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -7,7 +7,7 @@ import * as sinonChai from "sinon-chai";
 import * as vscode from "vscode";
 import path = require('path');
 import { fail } from "assert";
-import { fileExists, validateFileName } from "../../extension";
+import { fileExists, validateFileName } from "../../commands/file/create";
 import * as fs from "fs";
 
 const expect = chai.expect;

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -82,7 +82,7 @@ describe('Test Command: atlasmap.file.create', function() {
 		fs.mkdirSync(tempFolderUri);
 
 		workspaceSelectorStub.returns(workspaceFolder);
-		admLocationStub.returns("Select a folder inside workspace");
+		admLocationStub.returns("Select a folder inside Workspace");
 		dirPickerWindow.resolves([vscode.Uri.file(tempFolderUri)] as vscode.Uri[]);
 		fileNameInputStub.onFirstCall().returns(testADMFileName);
 

--- a/src/test/commands/atlasmap.file.create.test.ts
+++ b/src/test/commands/atlasmap.file.create.test.ts
@@ -70,7 +70,7 @@ describe('Test Command: atlasmap.file.create', function() {
 				
 		workspaceSelectorStub.returns(workspaceFolder);
 		admLocationStub.returns("");
-		fileNameInputStub.onFirstCall().returns(testADMFileName);
+		fileNameInputStub.returns(testADMFileName);
 
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');
@@ -92,8 +92,8 @@ describe('Test Command: atlasmap.file.create', function() {
 
 		workspaceSelectorStub.returns(workspaceFolder);
 		admLocationStub.returns("Select a folder inside Workspace");
-		dirPickerWindow.resolves([vscode.Uri.file(tempFolderUri)] as vscode.Uri[]);
-		fileNameInputStub.onFirstCall().returns(testADMFileName);
+		dirPickerWindow.returns([vscode.Uri.file(tempFolderUri)] as vscode.Uri[]);
+		fileNameInputStub.returns(testADMFileName);
 
 		try {
 			await vscode.commands.executeCommand('atlasmap.file.create');


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/FUSETOOLS2-1737

Provides a choice to select a directory inside the workspace for the adm file.

![AtlasMapAdmLocationChooser3](https://user-images.githubusercontent.com/17336236/190364478-9b14b84e-51a7-4813-b7ca-bff590b253f6.gif)
