### PR TITLE
Validate filename bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.2.2
 
+- Fixed a bug when using 'Create AtlasMap file' where name validation for files only considered the workspace root instead of the chosen folder.
+
 ## 0.2.1
 
 - Added an option when using 'Create AtlasMap file' action to choose the placement of the .adm file inside the workspace.

--- a/src/commands/file/create.ts
+++ b/src/commands/file/create.ts
@@ -30,7 +30,7 @@ export async function createAndOpenADM() {
 		}
 
 		const fileName: string | undefined 
-			= await promptForAdmFileName(selectedWorkspaceFolder);
+			= await promptForAdmFileName(vscode.Uri.file(admFolderPath));
 
 		if (fileName) {
 			await createAdmFile(admFolderPath, fileName);
@@ -77,7 +77,7 @@ async function promptUserForAdmFileLocationInWorkspace(workspaceRoot: vscode.Wor
 	return admFolderUri;
 }
 
-async function promptForAdmFileName(workspaceFolder : vscode.WorkspaceFolder)
+async function promptForAdmFileName(workspaceFolder : vscode.Uri)
 	: Promise<string | undefined> {
 	return vscode.window.showInputBox(
 		{placeHolder: "Enter the name of the new AtlasMap file",
@@ -124,8 +124,8 @@ function folderIsInside(parentFolder: string, subFolder: string) : boolean {
 	return !rel.startsWith('../') && rel !== '..';
 }
 
-export async function validateFileName(selectedWorkspaceFolder: vscode.WorkspaceFolder, fileName): Promise<string> {
-	const file: string = `${selectedWorkspaceFolder.uri.fsPath}/${getValidFileNameWithExtension(fileName)}`;
+export async function validateFileName(selectedWorkspaceFolder: vscode.Uri, fileName): Promise<string> {
+	const file: string = `${selectedWorkspaceFolder.fsPath}/${getValidFileNameWithExtension(fileName)}`;
 		if (!validFilename(fileName)) {
 			return 'The filename is invalid.';
 		}


### PR DESCRIPTION
Related ticket: https://issues.redhat.com/browse/FUSETOOLS2-1811

This fixes the issue where the validator was only validating at workspace root. Added some new tests that assert that the behaviour is as expected.

I'll be releasing this tomorrow after merging in 0.2.2