### PR TITLE
FUSETOOLS2-2176 - use Node 18 for build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,10 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Node 16
+      - name: Set up Node 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.15.x
           cache: npm
 
       - name: Set up JDK 11

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node('rhel8'){
 	}
 
 	stage('Install requirements') {
-		def nodeHome = tool 'nodejs-lts-16'
+		def nodeHome = tool 'nodejs-lts'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
 		sh "node --version"
 		sh "npm install -g typescript"


### PR DESCRIPTION
On Jenkins CI host, the ipV6 is now deactivated.
otherwise somewhere between the host and the npmjs website ipV6, a layer is not handling it correctly.